### PR TITLE
ci: add cargo-shear to check for unused dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,3 +126,40 @@ jobs:
       
       - name: Check formatting
         run: cargo fmt -- --check
+
+  cargo-shear:
+    name: Check unused dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.2.1
+      
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      
+      - name: Cache cargo registry
+        uses: actions/cache@v4.2.3
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+      
+      - name: Cache cargo index
+        uses: actions/cache@v4.2.3
+        with:
+          path: ~/.cargo/git
+          key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
+      
+      - name: Cache cargo build
+        uses: actions/cache@v4.2.3
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
+      
+      - name: Install cargo-shear
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-shear
+      
+      - name: Check for unused dependencies
+        run: cargo shear


### PR DESCRIPTION
## Summary
- Add cargo-shear to CI workflow to automatically detect unused dependencies
- Helps maintain a clean dependency list and improve build performance

## Changes
- Added new `cargo-shear` job to `.github/workflows/ci.yml`
- Uses `taiki-e/install-action@v2` to install cargo-shear
- Runs `cargo shear` command which fails if unused dependencies are found

## Benefits
- Automatically detects unused dependencies on every push
- Reduces compilation time by removing unnecessary dependencies
- Keeps binary size smaller
- Maintains cleaner `Cargo.toml` files

## Test plan
- [x] Verified cargo-shear runs successfully locally with no unused dependencies
- [ ] CI should pass on this PR since there are no unused dependencies