### PR TITLE
Update Cargo.lock after removing lazy_static dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,7 +244,6 @@ dependencies = [
  "futures",
  "globset",
  "indicatif",
- "lazy_static",
  "lru",
  "memmap2",
  "nom",


### PR DESCRIPTION
## Summary
- Update Cargo.lock to reflect the removal of lazy_static dependency
- This change was missed in the previous PR that migrated from lazy_static to std::sync::OnceLock

## Context
In PR #24, we migrated from `lazy_static` to `std::sync::OnceLock` but the Cargo.lock file wasn't updated at that time. This PR updates the lock file to keep it in sync with the dependency changes.

## Changes
- Remove lazy_static entry from Cargo.lock

## Test plan
- [x] Run `cargo build` successfully
- [x] Verify lazy_static is no longer in dependencies