### PR TITLE
Remove unused memmap2 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,7 +245,6 @@ dependencies = [
  "globset",
  "indicatif",
  "lru",
- "memmap2",
  "nom",
  "parse_datetime",
  "pprof",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,8 +53,6 @@ colored = "2.1"
 ratatui = "0.28"
 crossterm = "0.28"
 
-# Memory mapping for large files
-memmap2 = "0.9"
 
 # Profiling and tracing
 pprof = { version = "0.13", features = ["flamegraph", "prost-codec"], optional = true }

--- a/benches/component_benchmark.rs
+++ b/benches/component_benchmark.rs
@@ -47,17 +47,6 @@ fn benchmark_file_reading(c: &mut Criterion) {
             },
         );
 
-        group.bench_with_input(
-            BenchmarkId::new("mmap_read", size),
-            &test_file,
-            |b, test_file| {
-                b.iter(|| {
-                    let file = File::open(test_file).unwrap();
-                    let mmap = unsafe { memmap2::MmapOptions::new().map(&file).unwrap() };
-                    black_box(mmap.len())
-                });
-            },
-        );
     }
     group.finish();
 }


### PR DESCRIPTION
## Summary
- Removes the `memmap2` crate dependency from `Cargo.toml`
- Removes the `mmap_read` benchmark that was the only code using memmap2
- Reduces binary size and compilation time by eliminating unnecessary dependency

## Details
As noted in #25, the `memmap2` dependency was only used in benchmarks and not in production code. Benchmark results showed that the current streaming implementation is faster and more memory-efficient for typical use cases of searching Claude session JSONL files.

This PR removes:
1. The `memmap2` dependency from `Cargo.toml`
2. The `mmap_read` benchmark from `benches/component_benchmark.rs`

## Test plan
- [x] Verified code compiles without errors: `cargo check` ✅
- [x] Verified benchmarks still run correctly: `cargo bench component_benchmark -- --test` ✅
- [x] No production code changes, only benchmark code removal

Closes #25