### PR TITLE
Fix: Allow typing 's' in interactive search bar

### DIFF
--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -190,8 +190,7 @@ impl InteractiveSearch {
             | KeyCode::PageDown
             | KeyCode::Home
             | KeyCode::End
-            | KeyCode::Enter
-            | KeyCode::Char('s') => self.renderer.get_result_list_mut().handle_key(key),
+            | KeyCode::Enter => self.renderer.get_result_list_mut().handle_key(key),
             _ => self.renderer.get_search_bar_mut().handle_key(key),
         }
     }

--- a/src/interactive_ratatui/ui/components/result_list.rs
+++ b/src/interactive_ratatui/ui/components/result_list.rs
@@ -366,7 +366,6 @@ impl Component for ResultList {
                 }
             }
             KeyCode::Enter => Some(Message::EnterResultDetail),
-            KeyCode::Char('s') => Some(Message::EnterSessionViewer),
             _ => None,
         }
     }

--- a/src/interactive_ratatui/ui/components/result_list_test.rs
+++ b/src/interactive_ratatui/ui/components/result_list_test.rs
@@ -138,7 +138,7 @@ mod tests {
     }
 
     #[test]
-    fn test_enter_and_s_keys() {
+    fn test_enter_key() {
         let mut list = ResultList::new();
         let results = vec![create_test_result("user", "Test")];
         list.update_results(results, 0);
@@ -146,10 +146,6 @@ mod tests {
         // Enter should open detail view
         let msg = list.handle_key(create_key_event(KeyCode::Enter));
         assert!(matches!(msg, Some(Message::EnterResultDetail)));
-
-        // 's' should open session viewer
-        let msg = list.handle_key(create_key_event(KeyCode::Char('s')));
-        assert!(matches!(msg, Some(Message::EnterSessionViewer)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fixed an issue where users couldn't type the letter 's' in the interactive search bar
- Removed the 's' keyboard shortcut from search mode that was preventing normal text input
- Maintained session viewer accessibility through the result detail view

## Problem
In the interactive search mode, pressing 's' would trigger the session viewer shortcut instead of allowing users to type the letter 's' in their search queries. This made it impossible to search for terms containing the letter 's'.

## Solution
- Removed the `KeyCode::Char('s')` handler from the result list component's key handling in search mode
- The 's' key now properly goes to the search bar for text input
- Users can still access the session viewer by:
  1. Selecting a search result and pressing Enter to view details
  2. Pressing 's' in the result detail view to open the session viewer

## Test plan
- [x] Verified that 's' can be typed in the search bar
- [x] Confirmed session viewer is still accessible from result detail view
- [x] All tests pass (`cargo test`)
- [x] Updated the failing test that expected the old behavior