### PR TITLE
chore: update colored from 2.1 to 3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,7 +237,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "codspeed-criterion-compat",
- "colored",
+ "colored 3.0.0",
  "crossbeam",
  "crossterm",
  "dirs",
@@ -363,7 +363,7 @@ version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93f4cce9c27c49c4f101fffeebb1826f41a9df2e7498b7cd4d95c0658b796c6c"
 dependencies = [
- "colored",
+ "colored 2.2.0",
  "libc",
  "serde",
  "serde_json",
@@ -378,7 +378,7 @@ checksum = "c3c23d880a28a2aab52d38ca8481dd7a3187157d0a952196b6db1db3c8499725"
 dependencies = [
  "codspeed",
  "codspeed-criterion-compat-walltime",
- "colored",
+ "colored 2.2.0",
 ]
 
 [[package]]
@@ -421,6 +421,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "colored"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
+dependencies = [
  "windows-sys 0.59.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,7 +47,7 @@ nom = "7.1"
 indicatif = "0.18"
 
 # Colored output
-colored = "2.1"
+colored = "3.0"
 
 # TUI framework
 ratatui = "0.28"


### PR DESCRIPTION
## Summary
Update colored dependency from version 2.1 to 3.0 for improved terminal color support and bug fixes.

## Changes
- Updated `colored` from `2.1` to `3.0` in Cargo.toml
- Full API compatibility maintained with existing color formatting methods
- All tests and linting checks pass

## Testing
- ✅ All 192 unit tests pass
- ✅ Clippy linting passes without warnings
- ✅ Color formatting methods (`bright_blue()`, `bright_yellow()`, `bright_green()`, `dimmed()`) work unchanged

## Related
- Related to #12 (dependency updates tracking)
- Part of systematic dependency modernization per Renovate PR #1