### PR TITLE
Fix: Remove unwanted backspace navigation in session and detail views

### DIFF
--- a/src/interactive_ratatui/ui/components/result_detail.rs
+++ b/src/interactive_ratatui/ui/components/result_detail.rs
@@ -275,7 +275,7 @@ impl Component for ResultDetail {
                 .result
                 .as_ref()
                 .map(|result| Message::CopyToClipboard(result.text.clone())),
-            KeyCode::Backspace | KeyCode::Esc => Some(Message::ExitToSearch),
+            KeyCode::Esc => Some(Message::ExitToSearch),
             _ => None,
         }
     }

--- a/src/interactive_ratatui/ui/components/result_detail_test.rs
+++ b/src/interactive_ratatui/ui/components/result_detail_test.rs
@@ -222,10 +222,6 @@ mod tests {
         // Test exit to search (Esc)
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()));
         assert!(matches!(msg, Some(Message::ExitToSearch)));
-
-        // Test exit to search (Backspace)
-        let msg = detail.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::ExitToSearch)));
     }
 
     #[test]

--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -225,7 +225,7 @@ impl Component for SessionViewer {
                 KeyCode::Char('i') | KeyCode::Char('I') => {
                     self.session_id.clone().map(Message::CopyToClipboard)
                 }
-                KeyCode::Backspace | KeyCode::Esc => Some(Message::ExitToSearch),
+                KeyCode::Esc => Some(Message::ExitToSearch),
                 _ => None,
             }
         }

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -187,10 +187,6 @@ mod tests {
         // Test ESC key
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()));
         assert!(matches!(msg, Some(Message::ExitToSearch)));
-
-        // Test Backspace key
-        let msg = viewer.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::ExitToSearch)));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Remove backspace key handling from session viewer and result detail components
- Only Escape key now triggers navigation back to search view

## Problem
When users are in the session view or message detail view, pressing the backspace key currently navigates back to the previous screen. This behavior is problematic because backspace is commonly used for text editing and can lead to accidental navigation away from the current view.

## Solution
Removed `KeyCode::Backspace` from the key handling in both components, keeping only `KeyCode::Esc` for navigation:
- In `session_viewer.rs`: Changed from `KeyCode::Backspace | KeyCode::Esc` to just `KeyCode::Esc`
- In `result_detail.rs`: Same change applied

## Testing
✅ All tests updated and passing
✅ Build successful
✅ Manual testing confirmed:
  - Backspace no longer exits from session view
  - Backspace no longer exits from result detail view
  - Escape key still works for navigation in both views

Fixes #44