### PR TITLE
fix: session viewer search now works on displayed content

### DIFF
--- a/src/interactive_ratatui/application/session_service.rs
+++ b/src/interactive_ratatui/application/session_service.rs
@@ -2,6 +2,7 @@ use crate::SessionMessage;
 use crate::interactive_ratatui::application::cache_service::CacheService;
 use crate::interactive_ratatui::domain::filter::SessionFilter;
 use crate::interactive_ratatui::domain::models::SessionOrder;
+use crate::interactive_ratatui::domain::session_list_item::SessionListItem;
 use anyhow::Result;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
@@ -31,7 +32,14 @@ impl SessionService {
 
     #[allow(dead_code)]
     pub fn filter_messages(messages: &[String], query: &str) -> Vec<usize> {
-        SessionFilter::filter_messages(messages, query)
+        // Convert raw JSON strings to SessionListItems for search
+        let items: Vec<SessionListItem> = messages
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
+            .collect();
+        
+        SessionFilter::filter_messages(&items, query)
     }
 
     #[allow(dead_code)]

--- a/src/interactive_ratatui/application/session_service_test.rs
+++ b/src/interactive_ratatui/application/session_service_test.rs
@@ -42,10 +42,10 @@ mod tests {
     #[test]
     fn test_filter_messages_with_query() {
         let messages = vec![
-            "Hello world".to_string(),
-            "Goodbye world".to_string(),
-            "Hello again".to_string(),
-            "Something else".to_string(),
+            r#"{"type":"user","message":{"role":"user","content":"Hello world"},"uuid":"1","timestamp":"2024-12-25T14:30:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#.to_string(),
+            r#"{"type":"assistant","message":{"role":"assistant","content":"Goodbye world"},"uuid":"2","timestamp":"2024-12-25T14:31:00Z","sessionId":"session1","parentUuid":"1","isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#.to_string(),
+            r#"{"type":"user","message":{"role":"user","content":"Hello again"},"uuid":"3","timestamp":"2024-12-25T14:32:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#.to_string(),
+            r#"{"type":"system","content":"Something else","uuid":"4","timestamp":"2024-12-25T14:33:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#.to_string(),
         ];
 
         let indices = SessionService::filter_messages(&messages, "Hello");

--- a/src/interactive_ratatui/domain/filter.rs
+++ b/src/interactive_ratatui/domain/filter.rs
@@ -1,4 +1,5 @@
 use crate::query::condition::SearchResult;
+use crate::interactive_ratatui::domain::session_list_item::SessionListItem;
 use anyhow::Result;
 
 pub struct SearchFilter {
@@ -21,15 +22,18 @@ impl SearchFilter {
 pub struct SessionFilter;
 
 impl SessionFilter {
-    pub fn filter_messages(messages: &[String], query: &str) -> Vec<usize> {
+    pub fn filter_messages(items: &[SessionListItem], query: &str) -> Vec<usize> {
         if query.is_empty() {
-            (0..messages.len()).collect()
+            (0..items.len()).collect()
         } else {
             let query_lower = query.to_lowercase();
-            messages
+            items
                 .iter()
                 .enumerate()
-                .filter(|(_, msg)| msg.to_lowercase().contains(&query_lower))
+                .filter(|(_, item)| {
+                    let search_text = item.to_search_text();
+                    search_text.to_lowercase().contains(&query_lower)
+                })
                 .map(|(idx, _)| idx)
                 .collect()
         }

--- a/src/interactive_ratatui/domain/filter_test.rs
+++ b/src/interactive_ratatui/domain/filter_test.rs
@@ -81,13 +81,22 @@ mod tests {
 
     #[test]
     fn test_session_filter_empty_query() {
-        let messages = vec![
-            "Hello world".to_string(),
-            "How are you?".to_string(),
-            "I'm fine, thanks".to_string(),
+        use crate::interactive_ratatui::domain::session_list_item::SessionListItem;
+        
+        // Create test JSONL data
+        let jsonl_data = vec![
+            r#"{"type":"user","message":{"role":"user","content":"Hello world"},"uuid":"1","timestamp":"2024-12-25T14:30:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":"How are you?"},"uuid":"2","timestamp":"2024-12-25T14:31:00Z","sessionId":"session1","parentUuid":"1","isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"system","content":"I'm fine, thanks","uuid":"3","timestamp":"2024-12-25T14:32:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
         ];
 
-        let indices = SessionFilter::filter_messages(&messages, "");
+        let items: Vec<SessionListItem> = jsonl_data
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
+            .collect();
+
+        let indices = SessionFilter::filter_messages(&items, "");
 
         // Empty query should return all messages
         assert_eq!(indices, vec![0, 1, 2]);
@@ -95,56 +104,145 @@ mod tests {
 
     #[test]
     fn test_session_filter_case_insensitive() {
-        let messages = vec![
-            "Hello World".to_string(),
-            "goodbye world".to_string(),
-            "WORLD champion".to_string(),
-            "Something else".to_string(),
+        use crate::interactive_ratatui::domain::session_list_item::SessionListItem;
+        
+        let jsonl_data = vec![
+            r#"{"type":"user","message":{"role":"user","content":"Hello World"},"uuid":"1","timestamp":"2024-12-25T14:30:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":"goodbye world"},"uuid":"2","timestamp":"2024-12-25T14:31:00Z","sessionId":"session1","parentUuid":"1","isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"system","content":"WORLD champion","uuid":"3","timestamp":"2024-12-25T14:32:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"user","message":{"role":"user","content":"Something else"},"uuid":"4","timestamp":"2024-12-25T14:33:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
         ];
 
-        let indices = SessionFilter::filter_messages(&messages, "world");
+        let items: Vec<SessionListItem> = jsonl_data
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
+            .collect();
+
+        let indices = SessionFilter::filter_messages(&items, "world");
 
         assert_eq!(indices, vec![0, 1, 2]);
     }
 
     #[test]
     fn test_session_filter_partial_match() {
-        let messages = vec![
-            "The quick brown fox".to_string(),
-            "jumps over the lazy dog".to_string(),
-            "The fox is quick".to_string(),
+        use crate::interactive_ratatui::domain::session_list_item::SessionListItem;
+        
+        let jsonl_data = vec![
+            r#"{"type":"user","message":{"role":"user","content":"The quick brown fox"},"uuid":"1","timestamp":"2024-12-25T14:30:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":"jumps over the lazy dog"},"uuid":"2","timestamp":"2024-12-25T14:31:00Z","sessionId":"session1","parentUuid":"1","isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"system","content":"The fox is quick","uuid":"3","timestamp":"2024-12-25T14:32:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
         ];
 
-        let indices = SessionFilter::filter_messages(&messages, "fox");
+        let items: Vec<SessionListItem> = jsonl_data
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
+            .collect();
+
+        let indices = SessionFilter::filter_messages(&items, "fox");
 
         assert_eq!(indices, vec![0, 2]);
     }
 
     #[test]
     fn test_session_filter_unicode() {
-        let messages = vec![
-            "こんにちは世界".to_string(),
-            "Hello 世界".to_string(),
-            "世界 is world".to_string(),
-            "Something else".to_string(),
+        use crate::interactive_ratatui::domain::session_list_item::SessionListItem;
+        
+        let jsonl_data = vec![
+            r#"{"type":"user","message":{"role":"user","content":"こんにちは世界"},"uuid":"1","timestamp":"2024-12-25T14:30:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":"Hello 世界"},"uuid":"2","timestamp":"2024-12-25T14:31:00Z","sessionId":"session1","parentUuid":"1","isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"system","content":"世界 is world","uuid":"3","timestamp":"2024-12-25T14:32:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"user","message":{"role":"user","content":"Something else"},"uuid":"4","timestamp":"2024-12-25T14:33:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
         ];
 
-        let indices = SessionFilter::filter_messages(&messages, "世界");
+        let items: Vec<SessionListItem> = jsonl_data
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
+            .collect();
+
+        let indices = SessionFilter::filter_messages(&items, "世界");
 
         assert_eq!(indices, vec![0, 1, 2]);
     }
 
     #[test]
     fn test_session_filter_whitespace() {
-        let messages = vec![
-            "  Hello  World  ".to_string(),
-            "Hello\tWorld".to_string(),
-            "Hello\nWorld".to_string(),
+        use crate::interactive_ratatui::domain::session_list_item::SessionListItem;
+        
+        let jsonl_data = vec![
+            r#"{"type":"user","message":{"role":"user","content":"  Hello  World  "},"uuid":"1","timestamp":"2024-12-25T14:30:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":"Hello\tWorld"},"uuid":"2","timestamp":"2024-12-25T14:31:00Z","sessionId":"session1","parentUuid":"1","isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"system","content":"Hello\nWorld","uuid":"3","timestamp":"2024-12-25T14:32:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
         ];
 
-        let indices = SessionFilter::filter_messages(&messages, "Hello World");
+        let items: Vec<SessionListItem> = jsonl_data
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
+            .collect();
 
-        // Should match all since we normalize whitespace
-        assert_eq!(indices.len(), 0); // Currently doesn't handle this case
+        // Test various whitespace scenarios
+        
+        // Search for "Hello" should find all items
+        let hello_indices = SessionFilter::filter_messages(&items, "Hello");
+        assert_eq!(hello_indices, vec![0, 1, 2]);
+        
+        // Search for "World" should find all items (all contain "World")
+        let world_indices = SessionFilter::filter_messages(&items, "World");
+        assert_eq!(world_indices, vec![0, 1, 2]);
+        
+        // Search for exact "Hello World" (single space) won't match the multi-space version
+        let exact_indices = SessionFilter::filter_messages(&items, "Hello World");
+        assert_eq!(exact_indices, Vec::<usize>::new());
+        
+        // Search for "Hello\t" should find the tab version
+        let tab_indices = SessionFilter::filter_messages(&items, "Hello\t");
+        assert_eq!(tab_indices, vec![1]);
+        
+        // Search for "Hello\n" should find the newline version
+        let newline_indices = SessionFilter::filter_messages(&items, "Hello\n");
+        assert_eq!(newline_indices, vec![2]);
+    }
+
+    #[test]
+    fn test_session_filter_with_real_jsonl_data() {
+        use crate::interactive_ratatui::domain::session_list_item::SessionListItem;
+        
+        // This test validates that search now works on display text, not raw JSON
+        let jsonl_data = vec![
+            r#"{"type":"user","message":{"role":"user","content":"Hello, how can I help you?"},"uuid":"1","timestamp":"2024-12-25T14:30:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":"I'm here to assist you!"},"uuid":"2","timestamp":"2024-12-25T14:31:00Z","sessionId":"session1","parentUuid":"1","isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"system","content":"System initialized","uuid":"3","timestamp":"2024-12-25T14:32:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+        ];
+
+        let items: Vec<SessionListItem> = jsonl_data
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
+            .collect();
+
+        // These searches now work on display text as expected
+        
+        // Should find user messages when searching for display role
+        let user_search = SessionFilter::filter_messages(&items, "user");
+        assert_eq!(user_search.len(), 1); // Finds the user message
+        
+        // Should find messages with "12/25" in the formatted timestamp
+        let date_search = SessionFilter::filter_messages(&items, "12/25");
+        assert_eq!(date_search.len(), 3); // Now finds all messages because they all have the same date
+        
+        // Should work because "Hello" is in the content
+        let content_search = SessionFilter::filter_messages(&items, "Hello");
+        assert_eq!(content_search.len(), 1); // Finds the message with "Hello"
+        
+        // Should find assistant messages when searching for display role
+        let assistant_search = SessionFilter::filter_messages(&items, "assistant");
+        assert_eq!(assistant_search.len(), 1); // Finds the assistant message
+        
+        // Should find system messages when searching for display role
+        let system_search = SessionFilter::filter_messages(&items, "system");
+        assert_eq!(system_search.len(), 1); // Finds the system message
     }
 }

--- a/src/interactive_ratatui/domain/session_list_item.rs
+++ b/src/interactive_ratatui/domain/session_list_item.rs
@@ -11,6 +11,13 @@ pub struct SessionListItem {
 }
 
 impl SessionListItem {
+    /// Generates searchable text that matches what the user sees in the display
+    /// Format: "{formatted_timestamp} {role} {content}"
+    pub fn to_search_text(&self) -> String {
+        let formatted_timestamp = self.format_timestamp();
+        format!("{} {} {}", formatted_timestamp, self.role, self.content)
+    }
+
     pub fn from_json_line(index: usize, json_line: &str) -> Option<Self> {
         if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(json_line) {
             // Extract role/type

--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -247,9 +247,17 @@ impl AppState {
 
     fn update_session_filter(&mut self) {
         use crate::interactive_ratatui::domain::filter::SessionFilter;
+        use crate::interactive_ratatui::domain::session_list_item::SessionListItem;
+
+        // Convert raw JSON strings to SessionListItems for search
+        let items: Vec<SessionListItem> = self.session.messages
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
+            .collect();
 
         self.session.filtered_indices =
-            SessionFilter::filter_messages(&self.session.messages, &self.session.query);
+            SessionFilter::filter_messages(&items, &self.session.query);
 
         // Reset selection if current selection is out of bounds
         if self.session.selected_index >= self.session.filtered_indices.len() {

--- a/src/interactive_ratatui/ui/app_state_test.rs
+++ b/src/interactive_ratatui/ui/app_state_test.rs
@@ -167,9 +167,9 @@ mod tests {
     fn test_session_query_update() {
         let mut state = create_test_state();
         state.session.messages = vec![
-            "Hello world".to_string(),
-            "Goodbye world".to_string(),
-            "Hello again".to_string(),
+            r#"{"type":"user","message":{"role":"user","content":"Hello world"},"uuid":"1","timestamp":"2024-12-25T14:30:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#.to_string(),
+            r#"{"type":"assistant","message":{"role":"assistant","content":"Goodbye world"},"uuid":"2","timestamp":"2024-12-25T14:31:00Z","sessionId":"session1","parentUuid":"1","isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#.to_string(),
+            r#"{"type":"user","message":{"role":"user","content":"Hello again"},"uuid":"3","timestamp":"2024-12-25T14:32:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#.to_string(),
         ];
 
         let command = state.update(Message::SessionQueryChanged("Hello".to_string()));


### PR DESCRIPTION
## Summary
Fixes #35 - Session viewer search now works on displayed content instead of raw JSON

## Problem
Previously, SessionFilter searched raw JSON strings while SessionViewer displayed parsed/formatted content. Users would see formatted text like `[user] 12/25 14:30 Hello` but search operated on raw JSON like `{"type":"user","message":{"content":"Hello"}...}`, causing search mismatches.

## Solution
- Added `to_search_text()` method to SessionListItem to generate searchable text matching display format
- Modified `SessionFilter::filter_messages` to accept SessionListItem array instead of raw JSON strings
- Updated calling code in app_state.rs and session_service.rs to convert JSON to SessionListItem before filtering
- Fixed existing tests to use valid JSONL data instead of simple strings
- Added comprehensive test coverage for Unicode, whitespace, and case-insensitive search scenarios

## Test Coverage
- All 193 tests pass including 6 specific SessionFilter tests
- Comprehensive edge case testing (Unicode, whitespace, case sensitivity)
- Fixed 2 additional test failures that arose from the changes
- Clippy passes with no warnings

## Files Changed
- `src/interactive_ratatui/domain/session_list_item.rs` - Added `to_search_text()` method
- `src/interactive_ratatui/domain/filter.rs` - Updated filter logic
- `src/interactive_ratatui/ui/app_state.rs` - Updated filter calling code
- `src/interactive_ratatui/application/session_service.rs` - Updated filter wrapper
- Test files updated with proper JSONL data and comprehensive test cases

Closes #35