### PR TITLE
Add comprehensive copy functionality to Session Viewer

### DIFF
--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -80,6 +80,10 @@ impl SessionViewer {
         self.list_viewer.set_scroll_offset(offset);
     }
 
+    pub fn set_truncation_enabled(&mut self, enabled: bool) {
+        self.list_viewer.set_truncation_enabled(enabled);
+    }
+
     #[allow(dead_code)]
     pub fn start_search(&mut self) {
         self.is_searching = true;
@@ -162,7 +166,7 @@ impl Component for SessionViewer {
         self.list_viewer.render(f, chunks[2]);
 
         // Status bar
-        let status = "↑/↓: Navigate | o: Sort | c: Copy | C: Copy All | I: Copy Session ID | /: Search | Esc: Back";
+        let status = "↑/↓: Navigate | o: Sort | c: Copy JSON | C: Copy All | F: File | I: Session ID | M: Message | /: Search | Esc: Back";
         let status_bar = Paragraph::new(status).style(Style::default().fg(Color::DarkGray));
         f.render_widget(status_bar, chunks[3]);
     }
@@ -225,6 +229,13 @@ impl Component for SessionViewer {
                 KeyCode::Char('i') | KeyCode::Char('I') => {
                     self.session_id.clone().map(Message::CopyToClipboard)
                 }
+                KeyCode::Char('f') | KeyCode::Char('F') => {
+                    self.file_path.clone().map(Message::CopyToClipboard)
+                }
+                KeyCode::Char('m') | KeyCode::Char('M') => self
+                    .list_viewer
+                    .get_selected_item()
+                    .map(|item| Message::CopyToClipboard(item.content.clone())),
                 KeyCode::Esc => Some(Message::ExitToSearch),
                 _ => None,
             }

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -233,6 +233,30 @@ mod tests {
     }
 
     #[test]
+    fn test_truncation_toggle() {
+        let mut viewer = SessionViewer::new();
+        let messages = vec![
+            r#"{"type":"user","message":{"content":"This is a very long message that should be truncated when truncation is enabled but shown in full when truncation is disabled"},"timestamp":"2024-01-01T00:00:00Z"}"#.to_string(),
+        ];
+        
+        viewer.set_messages(messages);
+        
+        // Test with truncation enabled (default)
+        viewer.set_truncation_enabled(true);
+        let buffer = render_component(&mut viewer, 80, 24);
+        // The message should be truncated (ListViewer shows truncated line)
+        assert!(buffer_contains(&buffer, "user"));
+        
+        // Test with truncation disabled
+        viewer.set_truncation_enabled(false);
+        let buffer = render_component(&mut viewer, 80, 24);
+        // The message should show in full
+        assert!(buffer_contains(&buffer, "user"));
+        // Since we can't easily check for the full message content due to wrapping,
+        // at least verify the method doesn't crash
+    }
+
+    #[test]
     fn test_search_bar_rendering() {
         let mut viewer = SessionViewer::new();
         // Enter search mode first

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -238,15 +238,15 @@ mod tests {
         let messages = vec![
             r#"{"type":"user","message":{"content":"This is a very long message that should be truncated when truncation is enabled but shown in full when truncation is disabled"},"timestamp":"2024-01-01T00:00:00Z"}"#.to_string(),
         ];
-        
+
         viewer.set_messages(messages);
-        
+
         // Test with truncation enabled (default)
         viewer.set_truncation_enabled(true);
         let buffer = render_component(&mut viewer, 80, 24);
         // The message should be truncated (ListViewer shows truncated line)
         assert!(buffer_contains(&buffer, "user"));
-        
+
         // Test with truncation disabled
         viewer.set_truncation_enabled(false);
         let buffer = render_component(&mut viewer, 80, 24);

--- a/src/interactive_ratatui/ui/renderer.rs
+++ b/src/interactive_ratatui/ui/renderer.rs
@@ -104,6 +104,8 @@ impl Renderer {
             .set_selected_index(state.session.selected_index);
         self.session_viewer
             .set_scroll_offset(state.session.scroll_offset);
+        self.session_viewer
+            .set_truncation_enabled(state.ui.truncation_enabled);
 
         self.session_viewer.render(f, f.area());
     }


### PR DESCRIPTION
## Summary
- Added copy file path functionality (F key) to Session Viewer
- Added copy message text functionality (M key) to Session Viewer  
- Updated status bar to show all available copy options for better discoverability
- This PR also resolves the truncation toggle issue in Session Viewer

Closes #28

## Motivation
The Session Viewer had limited copy functionality compared to the Result Detail view. This PR adds the missing copy options to provide a consistent user experience across both views.

## Changes
- Added `F` key binding to copy the file path from `self.file_path`
- Added `M` key binding to copy the selected message's text content from `item.content`
- Updated the status bar text to clearly show all available copy shortcuts

## Testing
- Build passes successfully
- Copy functionality matches the pattern used in Result Detail view
- All existing functionality remains intact

## Before
Session Viewer only supported:
- `c` - Copy selected message's raw JSON
- `C` - Copy all raw messages  
- `I` - Copy session ID

## After
Session Viewer now supports:
- `c` - Copy selected message's raw JSON
- `C` - Copy all raw messages
- `F` - Copy file path
- `I` - Copy session ID
- `M` - Copy message text

This provides feature parity with the Result Detail view's copy functionality.