### PR TITLE
ci: optimize CodSpeed workflow to run only on Rust file changes

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -3,8 +3,16 @@ name: CodSpeed Performance Monitoring
 on:
   push:
     branches: [main, codespeed]
+    paths:
+      - '**.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
   pull_request:
     branches: [main]
+    paths:
+      - '**.rs'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
## Summary
- Modified the CodSpeed performance monitoring workflow to trigger only when Rust-related files are changed
- Added path filters for `**.rs`, `Cargo.toml`, and `Cargo.lock` files

## Why?
This optimization reduces unnecessary workflow runs when non-Rust files (like documentation, GitHub workflows, or configuration files) are modified. Since CodSpeed benchmarks are specific to Rust code performance, there's no need to run them when only non-Rust files change.

## Changes
- Added `paths` configuration to both `push` and `pull_request` triggers
- Workflow will now only run when:
  - Any `.rs` file is modified
  - `Cargo.toml` is modified (dependency changes)
  - `Cargo.lock` is modified (resolved dependency changes)

This change will help save CI resources and reduce unnecessary benchmark runs.