### PR TITLE
Fix: Keep search mode active when backspacing to empty query

### DIFF
--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -189,20 +189,13 @@ impl Component for SessionViewer {
                     None
                 }
                 _ => {
-                    // Handle special case for Backspace when query becomes empty
-                    if key.code == KeyCode::Backspace && self.text_input.text().len() == 1 {
-                        self.is_searching = false;
-                        self.text_input.handle_key(key);
-                        Some(Message::SessionQueryChanged(String::new()))
+                    let changed = self.text_input.handle_key(key);
+                    if changed {
+                        Some(Message::SessionQueryChanged(
+                            self.text_input.text().to_string(),
+                        ))
                     } else {
-                        let changed = self.text_input.handle_key(key);
-                        if changed {
-                            Some(Message::SessionQueryChanged(
-                                self.text_input.text().to_string(),
-                            ))
-                        } else {
-                            None
-                        }
+                        None
                     }
                 }
             }

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -684,4 +684,40 @@ mod tests {
         assert!(matches!(msg, Some(Message::SessionQueryChanged(q)) if q == "ell"));
         assert_eq!(viewer.cursor_position(), 0);
     }
+
+    #[test]
+    fn test_search_mode_stays_active_on_empty_backspace() {
+        let mut viewer = SessionViewer::new();
+        viewer.start_search();
+        
+        // Type a single character
+        viewer.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::empty()));
+        assert_eq!(viewer.query(), "a");
+        
+        // Backspace to empty - should stay in search mode
+        let msg = viewer.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::empty()));
+        assert!(matches!(msg, Some(Message::SessionQueryChanged(q)) if q.is_empty()));
+        
+        // Should still be in search mode - try typing again
+        let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::empty()));
+        assert!(matches!(msg, Some(Message::SessionQueryChanged(q)) if q == "b"));
+        
+        // Verify we're still in search mode - ESC should exit
+        let msg = viewer.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()));
+        assert!(matches!(msg, Some(Message::SessionQueryChanged(q)) if q.is_empty()));
+    }
+
+    #[test]
+    fn test_search_mode_backspace_on_empty_query() {
+        let mut viewer = SessionViewer::new();
+        viewer.start_search();
+        
+        // Backspace on empty query should do nothing but stay in search mode
+        let msg = viewer.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::empty()));
+        assert!(msg.is_none());
+        
+        // Should still be in search mode - can type
+        let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()));
+        assert!(matches!(msg, Some(Message::SessionQueryChanged(q)) if q == "x"));
+    }
 }

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -689,19 +689,19 @@ mod tests {
     fn test_search_mode_stays_active_on_empty_backspace() {
         let mut viewer = SessionViewer::new();
         viewer.start_search();
-        
+
         // Type a single character
         viewer.handle_key(KeyEvent::new(KeyCode::Char('a'), KeyModifiers::empty()));
         assert_eq!(viewer.query(), "a");
-        
+
         // Backspace to empty - should stay in search mode
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::empty()));
         assert!(matches!(msg, Some(Message::SessionQueryChanged(q)) if q.is_empty()));
-        
+
         // Should still be in search mode - try typing again
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::empty()));
         assert!(matches!(msg, Some(Message::SessionQueryChanged(q)) if q == "b"));
-        
+
         // Verify we're still in search mode - ESC should exit
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()));
         assert!(matches!(msg, Some(Message::SessionQueryChanged(q)) if q.is_empty()));
@@ -711,11 +711,11 @@ mod tests {
     fn test_search_mode_backspace_on_empty_query() {
         let mut viewer = SessionViewer::new();
         viewer.start_search();
-        
+
         // Backspace on empty query should do nothing but stay in search mode
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Backspace, KeyModifiers::empty()));
         assert!(msg.is_none());
-        
+
         // Should still be in search mode - can type
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::empty()));
         assert!(matches!(msg, Some(Message::SessionQueryChanged(q)) if q == "x"));


### PR DESCRIPTION
## Summary
- Fixed an issue where the session viewer would exit search mode when backspacing the search query to empty
- This improves UX consistency across different search interfaces in the application

## Problem
When using the session viewer's search functionality (`/` key), if a user typed a single character and then pressed backspace to delete it, the search mode would automatically exit. This was inconsistent with other search interfaces and could be frustrating for users who accidentally deleted their entire query and wanted to continue searching.

## Solution
Removed the special case handling that would exit search mode when the query becomes empty via backspace. Now users can:
- Stay in search mode even with an empty query
- Continue typing after backspacing everything
- Only exit search mode explicitly using Esc or Enter keys

## Test Plan
- [x] Added unit test `test_search_mode_stays_active_on_empty_backspace` to verify the fix
- [x] Added unit test `test_search_mode_backspace_on_empty_query` for edge case handling
- [x] All existing tests pass
- [x] Manual testing confirms the improved behavior

## Changes
- Modified `src/interactive_ratatui/ui/components/session_viewer.rs` to remove the special backspace handling
- Added comprehensive test coverage in `session_viewer_test.rs`