### PR TITLE
feat: Improve Session Viewer metadata display with vertical layout

### DIFF
--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -175,7 +175,7 @@ impl SessionViewer {
 impl Component for SessionViewer {
     fn render(&mut self, f: &mut Frame, area: Rect) {
         let subtitle = match (&self.session_id, &self.file_path) {
-            (Some(session), Some(file)) => format!("Session: {session} | File: {file}"),
+            (Some(session), Some(file)) => format!("Session: {session}\nFile: {file}"),
             (Some(session), None) => format!("Session: {session}"),
             (None, Some(file)) => format!("File: {file}"),
             (None, None) => String::new(),


### PR DESCRIPTION
## Summary
- Display SessionID and FilePath vertically in Session Viewer for better readability
- Implement automatic text wrapping for long paths using ratatui's built-in `Wrap` feature
- Add dynamic title bar height calculation to accommodate multi-line subtitles

## Changes
- Modified `session_viewer.rs` to format metadata with newline separator instead of pipe (`|`)
- Added `Wrap` widget to `view_layout.rs` for automatic text wrapping
- Implemented `calculate_title_bar_height()` method for dynamic layout adjustment
- Fixed syntax error (missing comma in match arm)

## Test Plan
- [x] Added comprehensive tests for vertical layout display
- [x] Added tests for empty and None file path scenarios
- [x] Added tests for long path wrapping behavior
- [x] All tests pass successfully

## Screenshots
Before:
```
Session: session-123 | File: /very/long/path/to/file.jsonl
```

After:
```
Session: session-123
File: /very/long/path/to/file.jsonl
```

Resolves the issue where file paths were not visible when they exceeded the screen width.