### PR TITLE
feat: Add search result highlighting in Session Viewer

### DIFF
--- a/src/interactive_ratatui/ui/components/list_viewer.rs
+++ b/src/interactive_ratatui/ui/components/list_viewer.rs
@@ -14,6 +14,7 @@ pub struct ListViewer<T: ListItem> {
     pub truncation_enabled: bool,
     pub title: String,
     pub empty_message: String,
+    query: String,
 }
 
 impl<T: ListItem> Default for ListViewer<T> {
@@ -26,6 +27,7 @@ impl<T: ListItem> Default for ListViewer<T> {
             truncation_enabled: true,
             title: String::new(),
             empty_message: String::new(),
+            query: String::new(),
         }
     }
 }
@@ -40,6 +42,7 @@ impl<T: ListItem> ListViewer<T> {
             truncation_enabled: true,
             title,
             empty_message,
+            query: String::new(),
         }
     }
 
@@ -74,6 +77,10 @@ impl<T: ListItem> ListViewer<T> {
 
     pub fn set_truncation_enabled(&mut self, enabled: bool) {
         self.truncation_enabled = enabled;
+    }
+
+    pub fn set_query(&mut self, query: String) {
+        self.query = query;
     }
 
     pub fn get_selected_item(&self) -> Option<&T> {
@@ -180,7 +187,7 @@ impl<T: ListItem> ListViewer<T> {
             while end < self.filtered_indices.len() && current_height < available_height as usize {
                 if let Some(&item_idx) = self.filtered_indices.get(end) {
                     if let Some(item) = self.items.get(item_idx) {
-                        let lines = item.create_full_lines(available_text_width);
+                        let lines = item.create_full_lines(available_text_width, &self.query);
                         let item_height = lines.len();
 
                         if current_height + item_height <= available_height as usize {
@@ -275,11 +282,15 @@ impl<T: ListItem> ListViewer<T> {
                         };
 
                         if self.truncation_enabled {
-                            TuiListItem::new(item.create_truncated_line(available_text_width))
-                                .style(style)
+                            TuiListItem::new(
+                                item.create_truncated_line(available_text_width, &self.query),
+                            )
+                            .style(style)
                         } else {
-                            TuiListItem::new(item.create_full_lines(available_text_width))
-                                .style(style)
+                            TuiListItem::new(
+                                item.create_full_lines(available_text_width, &self.query),
+                            )
+                            .style(style)
                         }
                     })
                 })

--- a/src/interactive_ratatui/ui/components/list_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/list_viewer_test.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod tests {
-    use super::super::list_item::ListItem;
+    use super::super::list_item::{ListItem, truncate_message, wrap_text};
     use super::super::list_viewer::ListViewer;
+    use ratatui::text::Line;
 
     // Mock implementation of ListItem for testing
     #[derive(Clone)]
@@ -22,6 +23,19 @@ mod tests {
 
         fn get_content(&self) -> &str {
             &self.content
+        }
+
+        fn create_truncated_line(&self, max_width: usize, _query: &str) -> Line<'static> {
+            let content = truncate_message(self.get_content(), max_width);
+            Line::from(content)
+        }
+
+        fn create_full_lines(&self, max_width: usize, _query: &str) -> Vec<Line<'static>> {
+            let wrapped_lines = wrap_text(self.get_content(), max_width);
+            wrapped_lines
+                .into_iter()
+                .map(|s| Line::from(s.to_string()))
+                .collect()
         }
     }
 

--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -80,7 +80,8 @@ impl SessionViewer {
     }
 
     pub fn set_query(&mut self, query: String) {
-        self.text_input.set_text(query);
+        self.text_input.set_text(query.clone());
+        self.list_viewer.set_query(query);
     }
 
     pub fn set_order(&mut self, order: Option<SessionOrder>) {


### PR DESCRIPTION
This PR implements search result highlighting in the Session Viewer. When a user searches in the session view, the matched text in the messages is now highlighted, making it easier to spot the search terms.\n\nCloses #81.