### PR TITLE
fix: remove ESC key exit behavior in search view

### DIFF
--- a/src/interactive_ratatui/integration_tests.rs
+++ b/src/interactive_ratatui/integration_tests.rs
@@ -248,12 +248,12 @@ mod tests {
     fn test_esc_key_behavior() {
         let mut app = InteractiveSearch::new(SearchOptions::default());
 
-        // ESC in search mode should exit
+        // ESC in search mode should NOT exit (only Ctrl+C twice exits)
         app.state.mode = Mode::Search;
         let should_exit = app
             .handle_input(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
             .unwrap();
-        assert!(should_exit);
+        assert!(!should_exit);
 
         // ESC in result detail should return to search
         app.state.mode = Mode::ResultDetail;

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -180,12 +180,6 @@ impl InteractiveSearch {
 
         // Global keys
         match key.code {
-            KeyCode::Esc => {
-                // Only exit from search mode
-                if self.state.mode == Mode::Search {
-                    return Ok(true);
-                }
-            }
             KeyCode::Char('?') if self.state.mode != Mode::Help => {
                 self.handle_message(Message::ShowHelp);
                 return Ok(false);


### PR DESCRIPTION
## Summary
- Removed immediate exit behavior when pressing ESC in search view
- Unified application exit mechanism to only use Ctrl+C pressed twice
- Updated tests to reflect the new behavior

## Changes
- **Removed ESC exit handler**: The ESC key no longer exits the application when pressed in search mode
- **Updated integration test**: Modified test expectation to reflect that ESC in search mode does not exit
- **Preserved ESC functionality in other views**: ESC still functions as a "back" button in ResultDetail, SessionViewer, and Help views

## Motivation
The previous behavior where ESC immediately exits the application in search view was inconsistent with the deliberate Ctrl+C twice exit mechanism. This change improves UX consistency by having a single, clear way to exit the application, preventing accidental exits.

## Test Plan
- [x] Modified and ran the `test_esc_key_behavior` test
- [x] Manually tested ESC behavior in all views
- [x] Verified Ctrl+C twice still exits as expected
- [x] Code compiles without warnings