### PR TITLE
feat: implement help dialog navigation with mode stack

### DIFF
--- a/src/interactive_ratatui/help_navigation_test.rs
+++ b/src/interactive_ratatui/help_navigation_test.rs
@@ -1,0 +1,149 @@
+#[cfg(test)]
+mod tests {
+    use crate::interactive_ratatui::ui::app_state::{AppState, Mode};
+    use crate::interactive_ratatui::ui::events::Message;
+    use crate::SearchOptions;
+
+    #[test]
+    fn test_help_dialog_navigation_from_search_mode() {
+        let mut state = AppState::new(SearchOptions::default(), 100);
+        assert_eq!(state.mode, Mode::Search);
+        assert!(state.mode_stack.is_empty());
+
+        // Show help from search mode
+        state.update(Message::ShowHelp);
+        assert_eq!(state.mode, Mode::Help);
+        assert_eq!(state.mode_stack.len(), 1);
+        assert_eq!(state.mode_stack[0], Mode::Search);
+
+        // Close help should return to search mode
+        state.update(Message::CloseHelp);
+        assert_eq!(state.mode, Mode::Search);
+        assert!(state.mode_stack.is_empty());
+    }
+
+    #[test]
+    fn test_help_dialog_navigation_from_result_detail_mode() {
+        let mut state = AppState::new(SearchOptions::default(), 100);
+        
+        // First navigate to result detail mode
+        // (We need to set up a result first)
+        state.search.results = vec![create_test_result()];
+        state.update(Message::EnterResultDetail);
+        assert_eq!(state.mode, Mode::ResultDetail);
+        assert_eq!(state.mode_stack.len(), 1);
+        assert_eq!(state.mode_stack[0], Mode::Search);
+
+        // Show help from result detail mode
+        state.update(Message::ShowHelp);
+        assert_eq!(state.mode, Mode::Help);
+        assert_eq!(state.mode_stack.len(), 2);
+        assert_eq!(state.mode_stack[0], Mode::Search);
+        assert_eq!(state.mode_stack[1], Mode::ResultDetail);
+
+        // Close help should return to result detail mode
+        state.update(Message::CloseHelp);
+        assert_eq!(state.mode, Mode::ResultDetail);
+        assert_eq!(state.mode_stack.len(), 1);
+        assert_eq!(state.mode_stack[0], Mode::Search);
+    }
+
+    #[test]
+    fn test_help_dialog_navigation_from_session_viewer_mode() {
+        let mut state = AppState::new(SearchOptions::default(), 100);
+        
+        // First navigate to session viewer mode
+        state.search.results = vec![create_test_result()];
+        state.update(Message::EnterSessionViewer);
+        assert_eq!(state.mode, Mode::SessionViewer);
+        assert_eq!(state.mode_stack.len(), 1);
+        assert_eq!(state.mode_stack[0], Mode::Search);
+
+        // Show help from session viewer mode
+        state.update(Message::ShowHelp);
+        assert_eq!(state.mode, Mode::Help);
+        assert_eq!(state.mode_stack.len(), 2);
+        assert_eq!(state.mode_stack[0], Mode::Search);
+        assert_eq!(state.mode_stack[1], Mode::SessionViewer);
+
+        // Close help should return to session viewer mode
+        state.update(Message::CloseHelp);
+        assert_eq!(state.mode, Mode::SessionViewer);
+        assert_eq!(state.mode_stack.len(), 1);
+        assert_eq!(state.mode_stack[0], Mode::Search);
+    }
+
+    #[test]
+    fn test_help_dialog_navigation_from_help_mode() {
+        let mut state = AppState::new(SearchOptions::default(), 100);
+        
+        // Show help
+        state.update(Message::ShowHelp);
+        assert_eq!(state.mode, Mode::Help);
+
+        // Trying to show help again from help mode should not change anything
+        // (This is prevented in the key handler, but test the state handling)
+        state.update(Message::ShowHelp);
+        assert_eq!(state.mode, Mode::Help);
+        assert_eq!(state.mode_stack.len(), 2); // Would push again if not prevented
+        
+        // Clean up the duplicate
+        state.mode_stack.pop();
+        
+        // Close help
+        state.update(Message::CloseHelp);
+        assert_eq!(state.mode, Mode::Search);
+    }
+
+    #[test]
+    fn test_help_dialog_navigation_complex_flow() {
+        let mut state = AppState::new(SearchOptions::default(), 100);
+        
+        // Navigate: Search -> ResultDetail -> SessionViewer -> Help
+        state.search.results = vec![create_test_result()];
+        state.update(Message::EnterResultDetail);
+        state.update(Message::EnterSessionViewer);
+        state.update(Message::ShowHelp);
+        
+        assert_eq!(state.mode, Mode::Help);
+        assert_eq!(state.mode_stack.len(), 3);
+        assert_eq!(state.mode_stack[0], Mode::Search);
+        assert_eq!(state.mode_stack[1], Mode::ResultDetail);
+        assert_eq!(state.mode_stack[2], Mode::SessionViewer);
+
+        // Close help should return to session viewer
+        state.update(Message::CloseHelp);
+        assert_eq!(state.mode, Mode::SessionViewer);
+        assert_eq!(state.mode_stack.len(), 2);
+
+        // Navigate back to search
+        state.update(Message::ExitToSearch);
+        assert_eq!(state.mode, Mode::ResultDetail);
+        state.update(Message::ExitToSearch);
+        assert_eq!(state.mode, Mode::Search);
+        assert!(state.mode_stack.is_empty());
+    }
+
+    // Helper function to create a test result
+    fn create_test_result() -> crate::query::condition::SearchResult {
+        use crate::query::condition::{SearchResult, QueryCondition};
+        
+        SearchResult {
+            file: "/test/file.jsonl".to_string(),
+            uuid: "test-uuid".to_string(),
+            timestamp: "2024-01-01T00:00:00Z".to_string(),
+            session_id: "test-session".to_string(),
+            role: "user".to_string(),
+            text: "Test content".to_string(),
+            has_tools: false,
+            has_thinking: false,
+            message_type: "user".to_string(),
+            query: QueryCondition::Literal {
+                pattern: "test".to_string(),
+                case_sensitive: false,
+            },
+            project_path: "/test/project".to_string(),
+            raw_json: Some(r#"{"type":"user","content":[{"type":"text","text":"Test content"}]}"#.to_string()),
+        }
+    }
+}

--- a/src/interactive_ratatui/help_navigation_test.rs
+++ b/src/interactive_ratatui/help_navigation_test.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod tests {
+    use crate::SearchOptions;
     use crate::interactive_ratatui::ui::app_state::{AppState, Mode};
     use crate::interactive_ratatui::ui::events::Message;
-    use crate::SearchOptions;
 
     #[test]
     fn test_help_dialog_navigation_from_search_mode() {
@@ -25,7 +25,7 @@ mod tests {
     #[test]
     fn test_help_dialog_navigation_from_result_detail_mode() {
         let mut state = AppState::new(SearchOptions::default(), 100);
-        
+
         // First navigate to result detail mode
         // (We need to set up a result first)
         state.search.results = vec![create_test_result()];
@@ -51,7 +51,7 @@ mod tests {
     #[test]
     fn test_help_dialog_navigation_from_session_viewer_mode() {
         let mut state = AppState::new(SearchOptions::default(), 100);
-        
+
         // First navigate to session viewer mode
         state.search.results = vec![create_test_result()];
         state.update(Message::EnterSessionViewer);
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn test_help_dialog_navigation_from_help_mode() {
         let mut state = AppState::new(SearchOptions::default(), 100);
-        
+
         // Show help
         state.update(Message::ShowHelp);
         assert_eq!(state.mode, Mode::Help);
@@ -86,10 +86,10 @@ mod tests {
         state.update(Message::ShowHelp);
         assert_eq!(state.mode, Mode::Help);
         assert_eq!(state.mode_stack.len(), 2); // Would push again if not prevented
-        
+
         // Clean up the duplicate
         state.mode_stack.pop();
-        
+
         // Close help
         state.update(Message::CloseHelp);
         assert_eq!(state.mode, Mode::Search);
@@ -98,13 +98,13 @@ mod tests {
     #[test]
     fn test_help_dialog_navigation_complex_flow() {
         let mut state = AppState::new(SearchOptions::default(), 100);
-        
+
         // Navigate: Search -> ResultDetail -> SessionViewer -> Help
         state.search.results = vec![create_test_result()];
         state.update(Message::EnterResultDetail);
         state.update(Message::EnterSessionViewer);
         state.update(Message::ShowHelp);
-        
+
         assert_eq!(state.mode, Mode::Help);
         assert_eq!(state.mode_stack.len(), 3);
         assert_eq!(state.mode_stack[0], Mode::Search);
@@ -126,8 +126,8 @@ mod tests {
 
     // Helper function to create a test result
     fn create_test_result() -> crate::query::condition::SearchResult {
-        use crate::query::condition::{SearchResult, QueryCondition};
-        
+        use crate::query::condition::{QueryCondition, SearchResult};
+
         SearchResult {
             file: "/test/file.jsonl".to_string(),
             uuid: "test-uuid".to_string(),
@@ -143,7 +143,9 @@ mod tests {
                 case_sensitive: false,
             },
             project_path: "/test/project".to_string(),
-            raw_json: Some(r#"{"type":"user","content":[{"type":"text","text":"Test content"}]}"#.to_string()),
+            raw_json: Some(
+                r#"{"type":"user","content":[{"type":"text","text":"Test content"}]}"#.to_string(),
+            ),
         }
     }
 }

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -18,13 +18,13 @@ mod domain;
 pub mod ui;
 
 #[cfg(test)]
+mod help_navigation_test;
+#[cfg(test)]
 mod integration_tests;
 #[cfg(test)]
 mod session_view_integration_test;
 #[cfg(test)]
 mod tests;
-#[cfg(test)]
-mod help_navigation_test;
 
 use self::application::{
     cache_service::CacheService, search_service::SearchService, session_service::SessionService,

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -23,6 +23,8 @@ mod integration_tests;
 mod session_view_integration_test;
 #[cfg(test)]
 mod tests;
+#[cfg(test)]
+mod help_navigation_test;
 
 use self::application::{
     cache_service::CacheService, search_service::SearchService, session_service::SessionService,

--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -159,11 +159,13 @@ impl AppState {
                 Command::None
             }
             Message::ShowHelp => {
+                self.mode_stack.push(self.mode);
                 self.mode = Mode::Help;
                 Command::None
             }
             Message::CloseHelp => {
-                self.mode = Mode::Search;
+                // Pop mode from stack if available, otherwise go to Search
+                self.mode = self.mode_stack.pop().unwrap_or(Mode::Search);
                 Command::None
             }
             Message::ToggleRoleFilter => {


### PR DESCRIPTION
## Summary
- Implemented proper navigation history for help dialog using mode_stack
- Help dialog now correctly returns to the previous mode instead of always returning to search mode
- Added comprehensive tests for navigation flow from all modes

## Changes
- Updated `ShowHelp` message handler to push current mode to mode_stack before switching to help mode
- Updated `CloseHelp` message handler to pop from mode_stack instead of hard-coding return to search mode
- Added comprehensive test suite (`help_navigation_test.rs`) covering all navigation scenarios
- Key binding (`?`) and renderer were already implemented, so no changes were needed there

## Test plan
- [x] Run existing tests: `cargo test interactive_ratatui --lib` (all 211 tests pass)
- [x] Run new help navigation tests: `cargo test help_navigation_test` (all 5 tests pass)
- [x] Build release: `cargo build --release` (successful)
- [x] Manual testing:
  - Press `?` from search mode → help dialog appears → press any key → returns to search mode
  - Navigate to result detail → press `?` → help dialog appears → press any key → returns to result detail
  - Navigate to session viewer → press `?` → help dialog appears → press any key → returns to session viewer

Fixes #80