### PR TITLE
revert: Revert PR #105 - CodSpeed CI workflow optimizations

### DIFF
--- a/.github/workflows/codspeed.yml
+++ b/.github/workflows/codspeed.yml
@@ -17,17 +17,10 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
-  CARGO_INCREMENTAL: 0
-  CARGO_NET_RETRY: 10
-  RUST_LOG: cargo_codspeed=info
 
 jobs:
   benchmarks:
     name: Run CodSpeed Benchmarks
-    # Runner configuration:
-    # - Public repos: ubuntu-latest provides 4 vCPU, 16GB RAM for FREE!
-    # - Private repos: ubuntu-latest only provides 2 vCPU, 7GB RAM
-    # - Larger runners (8+ cores) require GitHub Team/Enterprise plan
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -37,78 +30,34 @@ jobs:
         with:
           toolchain: stable
       
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y lld
-          echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld -C target-cpu=native" >> $GITHUB_ENV
-      
-      # Use sccache for better caching than artifacts
-      - name: Setup sccache
-        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
-      
-      - name: Configure sccache
-        run: |
-          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
-          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
-      
       - name: Cache cargo registry
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-registry-
       
       - name: Cache cargo index
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.cargo/git
           key: ${{ runner.os }}-cargo-index-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-index-
       
-      # Cache the entire target directory for benchmarks
-      - name: Cache target directory
+      - name: Cache cargo build
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: target
-          key: ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-${{ hashFiles('**/*.rs') }}-codspeed
-          restore-keys: |
-            ${{ runner.os }}-cargo-target-${{ hashFiles('**/Cargo.lock') }}-codspeed
-            ${{ runner.os }}-cargo-target-
+          key: ${{ runner.os }}-cargo-build-target-${{ hashFiles('**/Cargo.lock') }}
       
       - name: Install cargo-codspeed
         uses: taiki-e/install-action@11601f56230cbf5e7e891d41320906e40ca52d79 # v2.57.0
         with:
           tool: cargo-codspeed
       
-      - name: Display build info
-        run: |
-          echo "CPU info:"
-          lscpu | grep -E "Model name|CPU\(s\):|Thread\(s\) per core:|Core\(s\) per socket:"
-          echo "Memory info:"
-          free -h
-          echo "Disk space:"
-          df -h /
-          echo "Rust version:"
-          rustc --version
-          echo "cargo-codspeed version:"
-          cargo codspeed --version
-      
       - name: Build benchmarks
-        run: |
-          echo "Building benchmarks..."
-          time cargo codspeed build
-          echo "Build complete. Checking build artifacts..."
-          find target/codspeed -name "*.so" -o -name "*.dylib" | wc -l
+        run: cargo codspeed build
       
       - name: Run benchmarks
         uses: CodSpeedHQ/action@0b6e7a3d96c9d2a6057e7bcea6b45aaf2f7ce60b # v3.8.0
         with:
           run: cargo codspeed run
           token: ${{ secrets.CODSPEED_TOKEN }}
-      
-      - name: Show sccache stats
-        if: always()
-        run: sccache --show-stats


### PR DESCRIPTION
## Summary
Reverting PR #105 due to CI errors that started occurring after the merge.

## Changes
This PR reverts the following optimizations that were introduced in PR #105:
- Remove sccache Rust compilation caching
- Remove LLD linker configuration  
- Restore original caching strategy
- Remove diagnostic information and build optimizations

## Reason for Revert
CI has started showing errors after merging PR #105. Reverting to restore CI stability.

## Original PR
- PR: #105
- Title: perf: optimize CodSpeed CI workflow performance
- Commit: 96d969a

This is a clean revert of the merge commit.