### PR TITLE
feat: add role filtering to Session Viewer with Tab key

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,12 +151,24 @@ ccms -i -n 100                               # Adjust result limit
 - Results are limited by the `-n` flag (default: 50, but 20x more are loaded for scrolling)
 
 **Result Actions:**
-- `S` - View full session
+- `S` - View full session (Session Viewer)
 - `F` - Copy file path to clipboard
 - `I` - Copy session ID to clipboard
 - `P` - Copy project path to clipboard
 - `M` - Copy message text to clipboard
 - `R` - Copy raw JSON to clipboard
+
+**Session Viewer Controls:**
+- `↑/↓` or `j/k` - Navigate messages
+- `Tab` - Cycle role filters (all → user → assistant → system)
+- `/` - Search within session (Tab works in search mode too)
+- `O` - Toggle sort order
+- `Enter` - View message detail
+- `C` - Copy selected message
+- `Shift+C` - Copy all visible messages
+- `I` - Copy session ID
+- `F` - Copy file path
+- `Esc` - Return to previous screen
 
 ### Advanced Queries
 

--- a/spec.md
+++ b/spec.md
@@ -129,7 +129,7 @@ When 'S' is pressed in the full result view:
 │                                                                                │
 │ Showing X-Y of Z messages ↑/↓ to scroll                                        │
 └────────────────────────────────────────────────────────────────────────────────┘
-Enter: View | ↑/↓: Navigate | /: Search | I: Copy Session ID | O: Sort | C: Copy All | Esc: Back
+Enter: View | ↑/↓: Navigate | Tab: Role Filter | /: Search | I: Copy Session ID | O: Sort | C: Copy All | Esc: Back
 ```
 
 **Navigation**: Pressing Esc returns to the previous screen (typically ResultDetail), not directly to Search.
@@ -140,6 +140,7 @@ Enter: View | ↑/↓: Navigate | /: Search | I: Copy Session ID | O: Sort | C: 
    - Shows all messages in a scrollable list format
    - Each message displays: index, role (centered), timestamp, and preview text
    - Selected message is highlighted with ">" indicator and different background
+   - **Role Filter Display**: When active, shows "| Role: [role]" in the info bar
 
 2. **Interactive Search**:
    - Type to filter messages in real-time (no need to press '/')
@@ -147,12 +148,14 @@ Enter: View | ↑/↓: Navigate | /: Search | I: Copy Session ID | O: Sort | C: 
    - Shows filtered count: "Messages (123 total, 45 filtered)"
    - Backspace to delete characters, Esc to clear search
    - **Search result highlighting**: Matched text is highlighted in message previews
+   - **Tab key in search mode**: Role filter can be toggled even while typing search queries
 
 3. **Navigation and Actions**:
    - ↑/↓: Move selection through messages
    - PageUp/PageDown: Jump 10 messages at a time
    - Enter: View full message in detail view
    - /: Start search mode (interactive filtering)
+   - Tab: Cycle through role filters: None → user → assistant → system → None
    - O: Toggle sort order (Ascending/Descending/Original)
    - C: Copy selected message
    - Shift+C: Copy all visible (filtered) messages
@@ -472,6 +475,7 @@ struct SessionState {
     order: Option<SessionOrder>,      // Sort order
     file_path: Option<String>,        // Session file path
     session_id: Option<String>,       // Session identifier
+    role_filter: Option<String>,      // Active role filter
 }
 
 struct UIState {

--- a/src/interactive_ratatui/application/session_service.rs
+++ b/src/interactive_ratatui/application/session_service.rs
@@ -31,7 +31,7 @@ impl SessionService {
     }
 
     #[allow(dead_code)]
-    pub fn filter_messages(messages: &[String], query: &str) -> Vec<usize> {
+    pub fn filter_messages(messages: &[String], query: &str, role_filter: &Option<String>) -> Vec<usize> {
         // Convert raw JSON strings to SessionListItems for search
         let items: Vec<SessionListItem> = messages
             .iter()
@@ -39,7 +39,7 @@ impl SessionService {
             .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
             .collect();
 
-        SessionFilter::filter_messages(&items, query)
+        SessionFilter::filter_messages(&items, query, role_filter)
     }
 
     #[allow(dead_code)]

--- a/src/interactive_ratatui/application/session_service.rs
+++ b/src/interactive_ratatui/application/session_service.rs
@@ -31,7 +31,11 @@ impl SessionService {
     }
 
     #[allow(dead_code)]
-    pub fn filter_messages(messages: &[String], query: &str, role_filter: &Option<String>) -> Vec<usize> {
+    pub fn filter_messages(
+        messages: &[String],
+        query: &str,
+        role_filter: &Option<String>,
+    ) -> Vec<usize> {
         // Convert raw JSON strings to SessionListItems for search
         let items: Vec<SessionListItem> = messages
             .iter()

--- a/src/interactive_ratatui/application/session_service_test.rs
+++ b/src/interactive_ratatui/application/session_service_test.rs
@@ -34,7 +34,7 @@ mod tests {
     #[test]
     fn test_filter_messages_empty_list() {
         let messages: Vec<String> = vec![];
-        let indices = SessionService::filter_messages(&messages, "query");
+        let indices = SessionService::filter_messages(&messages, "query", &None);
 
         assert_eq!(indices.len(), 0);
     }
@@ -48,7 +48,7 @@ mod tests {
             r#"{"type":"system","content":"Something else","uuid":"4","timestamp":"2024-12-25T14:33:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#.to_string(),
         ];
 
-        let indices = SessionService::filter_messages(&messages, "Hello");
+        let indices = SessionService::filter_messages(&messages, "Hello", &None);
 
         assert_eq!(indices, vec![0, 2]);
     }

--- a/src/interactive_ratatui/domain/filter.rs
+++ b/src/interactive_ratatui/domain/filter.rs
@@ -26,9 +26,13 @@ impl SearchFilter {
 pub struct SessionFilter;
 
 impl SessionFilter {
-    pub fn filter_messages(items: &[SessionListItem], query: &str, role_filter: &Option<String>) -> Vec<usize> {
+    pub fn filter_messages(
+        items: &[SessionListItem],
+        query: &str,
+        role_filter: &Option<String>,
+    ) -> Vec<usize> {
         let query_lower = query.to_lowercase();
-        
+
         items
             .iter()
             .enumerate()
@@ -39,7 +43,7 @@ impl SessionFilter {
                         return false;
                     }
                 }
-                
+
                 // Then apply text filter
                 if query.is_empty() {
                     true

--- a/src/interactive_ratatui/domain/filter.rs
+++ b/src/interactive_ratatui/domain/filter.rs
@@ -26,20 +26,29 @@ impl SearchFilter {
 pub struct SessionFilter;
 
 impl SessionFilter {
-    pub fn filter_messages(items: &[SessionListItem], query: &str) -> Vec<usize> {
-        if query.is_empty() {
-            (0..items.len()).collect()
-        } else {
-            let query_lower = query.to_lowercase();
-            items
-                .iter()
-                .enumerate()
-                .filter(|(_, item)| {
+    pub fn filter_messages(items: &[SessionListItem], query: &str, role_filter: &Option<String>) -> Vec<usize> {
+        let query_lower = query.to_lowercase();
+        
+        items
+            .iter()
+            .enumerate()
+            .filter(|(_, item)| {
+                // Apply role filter first
+                if let Some(role) = role_filter {
+                    if item.role.to_lowercase() != role.to_lowercase() {
+                        return false;
+                    }
+                }
+                
+                // Then apply text filter
+                if query.is_empty() {
+                    true
+                } else {
                     let search_text = item.to_search_text();
                     search_text.to_lowercase().contains(&query_lower)
-                })
-                .map(|(idx, _)| idx)
-                .collect()
-        }
+                }
+            })
+            .map(|(idx, _)| idx)
+            .collect()
     }
 }

--- a/src/interactive_ratatui/domain/filter_test.rs
+++ b/src/interactive_ratatui/domain/filter_test.rs
@@ -96,7 +96,7 @@ mod tests {
             .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
             .collect();
 
-        let indices = SessionFilter::filter_messages(&items, "");
+        let indices = SessionFilter::filter_messages(&items, "", &None);
 
         // Empty query should return all messages
         assert_eq!(indices, vec![0, 1, 2]);
@@ -119,7 +119,7 @@ mod tests {
             .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
             .collect();
 
-        let indices = SessionFilter::filter_messages(&items, "world");
+        let indices = SessionFilter::filter_messages(&items, "world", &None);
 
         assert_eq!(indices, vec![0, 1, 2]);
     }
@@ -140,7 +140,7 @@ mod tests {
             .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
             .collect();
 
-        let indices = SessionFilter::filter_messages(&items, "fox");
+        let indices = SessionFilter::filter_messages(&items, "fox", &None);
 
         assert_eq!(indices, vec![0, 2]);
     }
@@ -162,7 +162,7 @@ mod tests {
             .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
             .collect();
 
-        let indices = SessionFilter::filter_messages(&items, "世界");
+        let indices = SessionFilter::filter_messages(&items, "世界", &None);
 
         assert_eq!(indices, vec![0, 1, 2]);
     }
@@ -186,23 +186,23 @@ mod tests {
         // Test various whitespace scenarios
 
         // Search for "Hello" should find all items
-        let hello_indices = SessionFilter::filter_messages(&items, "Hello");
+        let hello_indices = SessionFilter::filter_messages(&items, "Hello", &None);
         assert_eq!(hello_indices, vec![0, 1, 2]);
 
         // Search for "World" should find all items (all contain "World")
-        let world_indices = SessionFilter::filter_messages(&items, "World");
+        let world_indices = SessionFilter::filter_messages(&items, "World", &None);
         assert_eq!(world_indices, vec![0, 1, 2]);
 
         // Search for exact "Hello World" (single space) won't match the multi-space version
-        let exact_indices = SessionFilter::filter_messages(&items, "Hello World");
+        let exact_indices = SessionFilter::filter_messages(&items, "Hello World", &None);
         assert_eq!(exact_indices, Vec::<usize>::new());
 
         // Search for "Hello\t" should find the tab version
-        let tab_indices = SessionFilter::filter_messages(&items, "Hello\t");
+        let tab_indices = SessionFilter::filter_messages(&items, "Hello\t", &None);
         assert_eq!(tab_indices, vec![1]);
 
         // Search for "Hello\n" should find the newline version
-        let newline_indices = SessionFilter::filter_messages(&items, "Hello\n");
+        let newline_indices = SessionFilter::filter_messages(&items, "Hello\n", &None);
         assert_eq!(newline_indices, vec![2]);
     }
 
@@ -226,23 +226,114 @@ mod tests {
         // These searches now work on display text as expected
 
         // Should find user messages when searching for display role
-        let user_search = SessionFilter::filter_messages(&items, "user");
+        let user_search = SessionFilter::filter_messages(&items, "user", &None);
         assert_eq!(user_search.len(), 1); // Finds the user message
 
         // Should find messages with "12/25" in the formatted timestamp
-        let date_search = SessionFilter::filter_messages(&items, "12/25");
+        let date_search = SessionFilter::filter_messages(&items, "12/25", &None);
         assert_eq!(date_search.len(), 3); // Now finds all messages because they all have the same date
 
         // Should work because "Hello" is in the content
-        let content_search = SessionFilter::filter_messages(&items, "Hello");
+        let content_search = SessionFilter::filter_messages(&items, "Hello", &None);
         assert_eq!(content_search.len(), 1); // Finds the message with "Hello"
 
         // Should find assistant messages when searching for display role
-        let assistant_search = SessionFilter::filter_messages(&items, "assistant");
+        let assistant_search = SessionFilter::filter_messages(&items, "assistant", &None);
         assert_eq!(assistant_search.len(), 1); // Finds the assistant message
 
         // Should find system messages when searching for display role
-        let system_search = SessionFilter::filter_messages(&items, "system");
+        let system_search = SessionFilter::filter_messages(&items, "system", &None);
         assert_eq!(system_search.len(), 1); // Finds the system message
+    }
+
+    #[test]
+    fn test_session_filter_with_role_filter() {
+        use crate::interactive_ratatui::domain::session_list_item::SessionListItem;
+
+        let jsonl_data = [
+            r#"{"type":"user","message":{"role":"user","content":"Hello"},"uuid":"1","timestamp":"2024-12-25T14:30:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":"Hi there"},"uuid":"2","timestamp":"2024-12-25T14:31:00Z","sessionId":"session1","parentUuid":"1","isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"user","message":{"role":"user","content":"How are you?"},"uuid":"3","timestamp":"2024-12-25T14:32:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"system","content":"System message","uuid":"4","timestamp":"2024-12-25T14:33:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+        ];
+
+        let items: Vec<SessionListItem> = jsonl_data
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
+            .collect();
+
+        // Test with no role filter - should return all messages
+        let indices = SessionFilter::filter_messages(&items, "", &None);
+        assert_eq!(indices, vec![0, 1, 2, 3]);
+
+        // Test with user role filter - should return only user messages
+        let user_filter = Some("user".to_string());
+        let indices = SessionFilter::filter_messages(&items, "", &user_filter);
+        assert_eq!(indices, vec![0, 2]);
+
+        // Test with assistant role filter
+        let assistant_filter = Some("assistant".to_string());
+        let indices = SessionFilter::filter_messages(&items, "", &assistant_filter);
+        assert_eq!(indices, vec![1]);
+
+        // Test with system role filter
+        let system_filter = Some("system".to_string());
+        let indices = SessionFilter::filter_messages(&items, "", &system_filter);
+        assert_eq!(indices, vec![3]);
+    }
+
+    #[test]
+    fn test_session_filter_with_role_and_text_filter() {
+        use crate::interactive_ratatui::domain::session_list_item::SessionListItem;
+
+        let jsonl_data = [
+            r#"{"type":"user","message":{"role":"user","content":"Hello world"},"uuid":"1","timestamp":"2024-12-25T14:30:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"assistant","message":{"role":"assistant","content":"Hello there"},"uuid":"2","timestamp":"2024-12-25T14:31:00Z","sessionId":"session1","parentUuid":"1","isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"user","message":{"role":"user","content":"Goodbye"},"uuid":"3","timestamp":"2024-12-25T14:32:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"system","content":"Hello system","uuid":"4","timestamp":"2024-12-25T14:33:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+        ];
+
+        let items: Vec<SessionListItem> = jsonl_data
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
+            .collect();
+
+        // Test with text filter "Hello" and user role filter
+        let user_filter = Some("user".to_string());
+        let indices = SessionFilter::filter_messages(&items, "Hello", &user_filter);
+        assert_eq!(indices, vec![0]); // Only the first user message contains "Hello"
+
+        // Test with text filter "Hello" and assistant role filter
+        let assistant_filter = Some("assistant".to_string());
+        let indices = SessionFilter::filter_messages(&items, "Hello", &assistant_filter);
+        assert_eq!(indices, vec![1]); // Only the assistant message contains "Hello"
+
+        // Test with text filter "Hello" and no role filter
+        let indices = SessionFilter::filter_messages(&items, "Hello", &None);
+        assert_eq!(indices, vec![0, 1, 3]); // All messages containing "Hello"
+    }
+
+    #[test]
+    fn test_session_filter_case_insensitive_role() {
+        use crate::interactive_ratatui::domain::session_list_item::SessionListItem;
+
+        let jsonl_data = [
+            r#"{"type":"USER","message":{"role":"USER","content":"Hello"},"uuid":"1","timestamp":"2024-12-25T14:30:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"User","message":{"role":"User","content":"Hi"},"uuid":"2","timestamp":"2024-12-25T14:31:00Z","sessionId":"session1","parentUuid":"1","isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+            r#"{"type":"user","message":{"role":"user","content":"Hey"},"uuid":"3","timestamp":"2024-12-25T14:32:00Z","sessionId":"session1","parentUuid":null,"isSidechain":false,"userType":"external","cwd":"/test","version":"1.0"}"#,
+        ];
+
+        let items: Vec<SessionListItem> = jsonl_data
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
+            .collect();
+
+        // Test with lowercase role filter - should match all case variations
+        let user_filter = Some("user".to_string());
+        let indices = SessionFilter::filter_messages(&items, "", &user_filter);
+        assert_eq!(indices, vec![0, 1, 2]);
     }
 }

--- a/src/interactive_ratatui/integration_tests.rs
+++ b/src/interactive_ratatui/integration_tests.rs
@@ -349,6 +349,7 @@ mod tests {
                 order: None,
                 file_path: None,
                 session_id: None,
+                role_filter: None,
             },
             ui_state: UiStateSnapshot {
                 message: None,
@@ -383,6 +384,7 @@ mod tests {
                 order: None,
                 file_path: None,
                 session_id: None,
+                role_filter: None,
             },
             ui_state: UiStateSnapshot {
                 message: None,
@@ -930,5 +932,39 @@ mod tests {
                 .unwrap();
             assert!(should_exit, "Second Ctrl+C should exit from {mode:?}");
         }
+    }
+
+    /// Test session viewer role filter toggle
+    #[test]
+    fn test_session_viewer_role_filter() {
+        let mut app = InteractiveSearch::new(SearchOptions::default());
+        
+        // Set up session viewer mode
+        app.state.mode = Mode::SessionViewer;
+        app.state.session.messages = vec![
+            r#"{"type":"user","message":{"content":"Hello"},"timestamp":"2024-01-01T00:00:00Z"}"#.to_string(),
+            r#"{"type":"assistant","message":{"content":"Hi there"},"timestamp":"2024-01-01T00:01:00Z"}"#.to_string(),
+            r#"{"type":"system","content":"System message","timestamp":"2024-01-01T00:02:00Z"}"#.to_string(),
+        ];
+        
+        // Initially no role filter
+        assert_eq!(app.state.session.role_filter, None);
+        
+        // Tab key toggles role filter
+        let tab_key = KeyEvent::new(KeyCode::Tab, KeyModifiers::empty());
+        app.handle_input(tab_key).unwrap();
+        assert_eq!(app.state.session.role_filter, Some("user".to_string()));
+        
+        // Tab again - cycles to assistant
+        app.handle_input(tab_key).unwrap();
+        assert_eq!(app.state.session.role_filter, Some("assistant".to_string()));
+        
+        // Tab again - cycles to system
+        app.handle_input(tab_key).unwrap();
+        assert_eq!(app.state.session.role_filter, Some("system".to_string()));
+        
+        // Tab again - cycles back to None
+        app.handle_input(tab_key).unwrap();
+        assert_eq!(app.state.session.role_filter, None);
     }
 }

--- a/src/interactive_ratatui/integration_tests.rs
+++ b/src/interactive_ratatui/integration_tests.rs
@@ -938,7 +938,7 @@ mod tests {
     #[test]
     fn test_session_viewer_role_filter() {
         let mut app = InteractiveSearch::new(SearchOptions::default());
-        
+
         // Set up session viewer mode
         app.state.mode = Mode::SessionViewer;
         app.state.session.messages = vec![
@@ -946,23 +946,23 @@ mod tests {
             r#"{"type":"assistant","message":{"content":"Hi there"},"timestamp":"2024-01-01T00:01:00Z"}"#.to_string(),
             r#"{"type":"system","content":"System message","timestamp":"2024-01-01T00:02:00Z"}"#.to_string(),
         ];
-        
+
         // Initially no role filter
         assert_eq!(app.state.session.role_filter, None);
-        
+
         // Tab key toggles role filter
         let tab_key = KeyEvent::new(KeyCode::Tab, KeyModifiers::empty());
         app.handle_input(tab_key).unwrap();
         assert_eq!(app.state.session.role_filter, Some("user".to_string()));
-        
+
         // Tab again - cycles to assistant
         app.handle_input(tab_key).unwrap();
         assert_eq!(app.state.session.role_filter, Some("assistant".to_string()));
-        
+
         // Tab again - cycles to system
         app.handle_input(tab_key).unwrap();
         assert_eq!(app.state.session.role_filter, Some("system".to_string()));
-        
+
         // Tab again - cycles back to None
         app.handle_input(tab_key).unwrap();
         assert_eq!(app.state.session.role_filter, None);

--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -444,7 +444,8 @@ impl AppState {
             .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
             .collect();
 
-        self.session.filtered_indices = SessionFilter::filter_messages(&items, &self.session.query, &self.session.role_filter);
+        self.session.filtered_indices =
+            SessionFilter::filter_messages(&items, &self.session.query, &self.session.role_filter);
 
         // Reset selection if current selection is out of bounds
         if self.session.selected_index >= self.session.filtered_indices.len() {

--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -41,6 +41,7 @@ pub struct SessionState {
     pub order: Option<SessionOrder>,
     pub file_path: Option<String>,
     pub session_id: Option<String>,
+    pub role_filter: Option<String>,
 }
 
 pub struct UiState {
@@ -73,6 +74,7 @@ impl AppState {
                 order: None,
                 file_path: None,
                 session_id: None,
+                role_filter: None,
             },
             ui: UiState {
                 message: None,
@@ -260,6 +262,17 @@ impl AppState {
                 self.update_session_filter();
                 Command::None
             }
+            Message::ToggleSessionRoleFilter => {
+                self.session.role_filter = match &self.session.role_filter {
+                    None => Some("user".to_string()),
+                    Some(r) if r == "user" => Some("assistant".to_string()),
+                    Some(r) if r == "assistant" => Some("system".to_string()),
+                    _ => None,
+                };
+                // Re-apply filter with new role
+                self.update_session_filter();
+                Command::None
+            }
             Message::SetStatus(msg) => {
                 self.ui.message = Some(msg);
                 Command::None
@@ -431,7 +444,7 @@ impl AppState {
             .filter_map(|(idx, line)| SessionListItem::from_json_line(idx, line))
             .collect();
 
-        self.session.filtered_indices = SessionFilter::filter_messages(&items, &self.session.query);
+        self.session.filtered_indices = SessionFilter::filter_messages(&items, &self.session.query, &self.session.role_filter);
 
         // Reset selection if current selection is out of bounds
         if self.session.selected_index >= self.session.filtered_indices.len() {
@@ -460,6 +473,7 @@ impl AppState {
                 order: self.session.order,
                 file_path: self.session.file_path.clone(),
                 session_id: self.session.session_id.clone(),
+                role_filter: self.session.role_filter.clone(),
             },
             ui_state: UiStateSnapshot {
                 message: self.ui.message.clone(),
@@ -490,6 +504,7 @@ impl AppState {
         self.session.order = state.session_state.order;
         self.session.file_path = state.session_state.file_path.clone();
         self.session.session_id = state.session_state.session_id.clone();
+        self.session.role_filter = state.session_state.role_filter.clone();
 
         // Restore UI state
         self.ui.message = state.ui_state.message.clone();

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -1046,14 +1046,14 @@ mod tests {
     #[test]
     fn test_role_filter_toggle() {
         let mut viewer = SessionViewer::new();
-        
+
         // Tab key toggles role filter
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::empty()));
         assert!(matches!(msg, Some(Message::ToggleSessionRoleFilter)));
-        
+
         // Tab key should return the message for state management to handle
     }
-    
+
     #[test]
     fn test_role_filter_display() {
         let mut viewer = SessionViewer::new();
@@ -1061,32 +1061,32 @@ mod tests {
             r#"{"type":"user","message":{"content":"Hello"},"timestamp":"2024-01-01T00:00:00Z"}"#.to_string(),
             r#"{"type":"assistant","message":{"content":"Hi there"},"timestamp":"2024-01-01T00:01:00Z"}"#.to_string(),
         ]);
-        
+
         // Test without role filter
         viewer.set_role_filter(None);
         let buffer = render_component(&mut viewer, 100, 30);
         assert!(!buffer_contains(&buffer, "Role:"));
-        
+
         // Test with user filter
         viewer.set_role_filter(Some("user".to_string()));
         let buffer = render_component(&mut viewer, 100, 30);
         assert!(buffer_contains(&buffer, "Role: user"));
-        
+
         // Test with assistant filter
         viewer.set_role_filter(Some("assistant".to_string()));
         let buffer = render_component(&mut viewer, 100, 30);
         assert!(buffer_contains(&buffer, "Role: assistant"));
-        
+
         // Test with system filter
         viewer.set_role_filter(Some("system".to_string()));
         let buffer = render_component(&mut viewer, 100, 30);
         assert!(buffer_contains(&buffer, "Role: system"));
     }
-    
+
     #[test]
     fn test_tab_key_not_processed_with_ctrl_modifier() {
         let mut viewer = SessionViewer::new();
-        
+
         // Tab with CTRL modifier should not trigger role filter toggle
         let msg = viewer.handle_key(create_key_event_with_modifiers(
             KeyCode::Tab,
@@ -1098,10 +1098,10 @@ mod tests {
     #[test]
     fn test_role_filter_toggle_in_search_mode() {
         let mut viewer = SessionViewer::new();
-        
+
         // Enter search mode
         viewer.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::empty()));
-        
+
         // Tab key should toggle role filter even in search mode
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::empty()));
         assert!(matches!(msg, Some(Message::ToggleSessionRoleFilter)));
@@ -1110,10 +1110,10 @@ mod tests {
     #[test]
     fn test_search_mode_role_filter_help_text() {
         let mut viewer = SessionViewer::new();
-        
+
         // Enter search mode
         viewer.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::empty()));
-        
+
         let buffer = render_component(&mut viewer, 100, 30);
         assert!(buffer_contains(&buffer, "Tab: Role Filter"));
     }

--- a/src/interactive_ratatui/ui/events.rs
+++ b/src/interactive_ratatui/ui/events.rs
@@ -32,6 +32,7 @@ pub enum Message {
     SessionSelectDown,
     SessionNavigated,
     ToggleSessionOrder,
+    ToggleSessionRoleFilter,
 
     // Role filter
     ToggleRoleFilter,

--- a/src/interactive_ratatui/ui/navigation.rs
+++ b/src/interactive_ratatui/ui/navigation.rs
@@ -31,6 +31,7 @@ pub struct SessionStateSnapshot {
     pub order: Option<SessionOrder>,
     pub file_path: Option<String>,
     pub session_id: Option<String>,
+    pub role_filter: Option<String>,
 }
 
 /// Snapshot of UI state
@@ -185,6 +186,7 @@ mod tests {
                 order: None,
                 file_path: None,
                 session_id: None,
+                role_filter: None,
             },
             ui_state: UiStateSnapshot {
                 message: None,

--- a/src/interactive_ratatui/ui/renderer.rs
+++ b/src/interactive_ratatui/ui/renderer.rs
@@ -101,6 +101,8 @@ impl Renderer {
         self.session_viewer
             .set_session_id(state.session.session_id.clone());
         self.session_viewer.set_message(state.ui.message.clone());
+        self.session_viewer
+            .set_role_filter(state.session.role_filter.clone());
         // Don't override the internal ListViewer's selected_index and scroll_offset
         // self.session_viewer
         //     .set_selected_index(state.session.selected_index);


### PR DESCRIPTION
## Summary
- Implement role filtering in Session Viewer using Tab key navigation
- Add support for role filtering in both normal and search modes
- Update documentation and tests

## Details
This PR adds role filtering functionality to the Session Viewer, matching the behavior found in the Search mode. Users can now press Tab to cycle through role filters: None → user → assistant → system → None.

### Key Features
- **Tab Key Navigation**: Press Tab to cycle through role filters in Session Viewer
- **Search Mode Support**: Tab key works even when typing in search mode (after pressing '/')
- **Visual Feedback**: Current role filter is displayed in the info bar
- **State Preservation**: Role filter state is preserved during navigation
- **Comprehensive Tests**: Added unit tests, integration tests, and updated documentation

### Implementation Details
- Added `role_filter: Option<String>` to `SessionState`
- Created `ToggleSessionRoleFilter` message type
- Updated `SessionFilter::filter_messages` to accept role_filter parameter
- Modified SessionViewer component to handle Tab key in both modes
- Updated UI to show current role filter and Tab key shortcut

### Documentation
- Updated `spec.md` with role filtering documentation
- Updated `README.md` with Session Viewer controls including role filtering

## Test plan
- [x] Unit tests for role filter toggle functionality
- [x] Integration tests for role filter cycling
- [x] Tests for role filtering in search mode
- [x] Manual testing of UI feedback and state preservation
- [x] All tests passing
- [x] Clippy checks passing