### PR TITLE
feat: add vim-style Ctrl+u/d half-page scrolling and remove j/k navigation

### DIFF
--- a/src/interactive_ratatui/constants.rs
+++ b/src/interactive_ratatui/constants.rs
@@ -17,9 +17,6 @@ pub const DOUBLE_CTRL_C_TIMEOUT_SECS: u64 = 1;
 /// Height of the search bar component
 pub const SEARCH_BAR_HEIGHT: u16 = 3;
 
-/// Height of the status bar
-pub const STATUS_BAR_HEIGHT: u16 = 1;
-
 /// Page size for PageUp/PageDown navigation
 pub const PAGE_SIZE: usize = 10;
 

--- a/src/interactive_ratatui/integration_tests.rs
+++ b/src/interactive_ratatui/integration_tests.rs
@@ -88,6 +88,38 @@ mod tests {
             .unwrap();
     }
 
+    /// Test that status bar is not duplicated
+    #[test]
+    fn test_no_duplicate_status_bar() {
+        let mut app = InteractiveSearch::new(SearchOptions::default());
+        let backend = TestBackend::new(80, 24);
+        let mut terminal = Terminal::new(backend).unwrap();
+
+        // Add some results to make the UI more realistic
+        app.state.search.results = vec![
+            create_test_result("user", "Test message", "2024-01-01T12:00:00Z"),
+        ];
+
+        // Render the search mode
+        app.set_mode(Mode::Search);
+        terminal
+            .draw(|f| app.renderer.render(f, &app.state))
+            .unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let content = buffer_to_string(buffer);
+
+        // Count occurrences of key status bar elements
+        let navigate_count = content.matches("Navigate").count();
+        let filter_count = content.matches("Tab: Filter").count();
+        let help_count = content.matches("?: Help").count();
+
+        // Each element should appear exactly once
+        assert_eq!(navigate_count, 1, "Navigate should appear exactly once");
+        assert_eq!(filter_count, 1, "Tab: Filter should appear exactly once");
+        assert_eq!(help_count, 1, "?: Help should appear exactly once");
+    }
+
     /// Test error handling in various scenarios
     #[test]
     fn test_error_handling_scenarios() {
@@ -225,6 +257,21 @@ mod tests {
             }
         }
         false
+    }
+
+    fn buffer_to_string(buffer: &Buffer) -> String {
+        let content = buffer.area.x..buffer.area.x + buffer.area.width;
+        let lines = buffer.area.y..buffer.area.y + buffer.area.height;
+        let mut result = String::new();
+
+        for y in lines {
+            for x in content.clone() {
+                let cell = &buffer[(x, y)];
+                result.push_str(cell.symbol());
+            }
+            result.push('\n');
+        }
+        result
     }
 
     /// Test that initial search query doesn't show pattern in search bar

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -233,6 +233,14 @@ impl InteractiveSearch {
             | KeyCode::Home
             | KeyCode::End
             | KeyCode::Enter => self.renderer.get_result_list_mut().handle_key(key),
+            // Ctrl+P/N navigation
+            KeyCode::Char('p') | KeyCode::Char('n') if key.modifiers == KeyModifiers::CONTROL => {
+                self.renderer.get_result_list_mut().handle_key(key)
+            }
+            // Handle Ctrl+u/d for half-page scrolling
+            KeyCode::Char('u') | KeyCode::Char('d') if key.modifiers == KeyModifiers::CONTROL => {
+                self.renderer.get_result_list_mut().handle_key(key)
+            }
             _ => self.renderer.get_search_bar_mut().handle_key(key),
         }
     }

--- a/src/interactive_ratatui/ui/components/list_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/list_viewer_test.rs
@@ -181,6 +181,69 @@ mod tests {
     }
 
     #[test]
+    fn test_half_page_navigation() {
+        let mut viewer = ListViewer::<MockListItem>::new("Test".to_string(), "Empty".to_string());
+        let items = create_mock_items(30);
+        viewer.set_items(items);
+
+        // Set a viewport height for testing
+        viewer.set_last_viewport_height(10);
+
+        // Test half_page_down
+        assert_eq!(viewer.selected_index, 0);
+        assert!(viewer.half_page_down());
+        assert_eq!(viewer.selected_index, 5); // Half of 10
+
+        assert!(viewer.half_page_down());
+        assert_eq!(viewer.selected_index, 10);
+
+        // Navigate to near the end
+        viewer.selected_index = 25;
+        assert!(viewer.half_page_down());
+        assert_eq!(viewer.selected_index, 29); // Can't go past last item
+
+        // Test that we can't scroll past the end
+        assert!(!viewer.half_page_down());
+        assert_eq!(viewer.selected_index, 29);
+
+        // Test half_page_up
+        assert!(viewer.half_page_up());
+        assert_eq!(viewer.selected_index, 24); // 29 - 5
+
+        viewer.selected_index = 3;
+        assert!(viewer.half_page_up());
+        assert_eq!(viewer.selected_index, 0); // Can't go below 0
+
+        // Test that we can't scroll past the start
+        assert!(!viewer.half_page_up());
+        assert_eq!(viewer.selected_index, 0);
+    }
+
+    #[test]
+    fn test_half_page_navigation_with_different_viewport_sizes() {
+        let mut viewer = ListViewer::<MockListItem>::new("Test".to_string(), "Empty".to_string());
+        let items = create_mock_items(50);
+        viewer.set_items(items);
+
+        // Test with viewport height of 20
+        viewer.set_last_viewport_height(20);
+        assert!(viewer.half_page_down());
+        assert_eq!(viewer.selected_index, 10); // Half of 20
+
+        // Test with viewport height of 7 (odd number)
+        viewer.selected_index = 0;
+        viewer.set_last_viewport_height(7);
+        assert!(viewer.half_page_down());
+        assert_eq!(viewer.selected_index, 3); // Floor of 7/2
+
+        // Test with very small viewport
+        viewer.selected_index = 0;
+        viewer.set_last_viewport_height(2);
+        assert!(viewer.half_page_down());
+        assert_eq!(viewer.selected_index, 1);
+    }
+
+    #[test]
     fn test_filtered_navigation() {
         let mut viewer = ListViewer::<MockListItem>::new("Test".to_string(), "Empty".to_string());
         let items = create_mock_items(10);

--- a/src/interactive_ratatui/ui/components/result_detail.rs
+++ b/src/interactive_ratatui/ui/components/result_detail.rs
@@ -143,7 +143,7 @@ impl ResultDetail {
         let total_lines = all_lines.len();
         let detail = Paragraph::new(display_lines)
             .block(Block::default().borders(Borders::ALL).title(format!(
-                "Result Detail (↑/↓ or j/k to scroll, line {}/{})",
+                "Result Detail (↑/↓ to scroll, line {}/{})",
                 self.scroll_offset + 1,
                 total_lines
             )))
@@ -186,7 +186,7 @@ impl ResultDetail {
                 Span::styled(" - Navigate history", Styles::action_description()),
             ]),
             Line::from(vec![
-                Span::styled("[↑/↓ or j/k]", Styles::action_key()),
+                Span::styled("[↑/↓]", Styles::action_key()),
                 Span::styled(" - Scroll message", Styles::action_description()),
             ]),
         ];
@@ -227,13 +227,13 @@ impl Component for ResultDetail {
 
     fn handle_key(&mut self, key: KeyEvent) -> Option<Message> {
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
+            KeyCode::Up => {
                 if self.scroll_offset > 0 {
                     self.scroll_offset -= 1;
                 }
                 None
             }
-            KeyCode::Down | KeyCode::Char('j') => {
+            KeyCode::Down => {
                 self.scroll_offset += 1;
                 None
             }

--- a/src/interactive_ratatui/ui/components/result_detail_test.rs
+++ b/src/interactive_ratatui/ui/components/result_detail_test.rs
@@ -201,8 +201,8 @@ mod tests {
         assert!(msg.is_none());
         assert_eq!(detail.scroll_offset, 1);
 
-        // Test scroll down with 'j'
-        let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty()));
+        // Test scroll down again
+        let msg = detail.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()));
         assert!(msg.is_none());
         assert_eq!(detail.scroll_offset, 2);
 
@@ -211,8 +211,8 @@ mod tests {
         assert!(msg.is_none());
         assert_eq!(detail.scroll_offset, 1);
 
-        // Test scroll up with 'k'
-        let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::empty()));
+        // Test scroll up again
+        let msg = detail.handle_key(KeyEvent::new(KeyCode::Up, KeyModifiers::empty()));
         assert!(msg.is_none());
         assert_eq!(detail.scroll_offset, 0);
 

--- a/src/interactive_ratatui/ui/components/result_list.rs
+++ b/src/interactive_ratatui/ui/components/result_list.rs
@@ -46,13 +46,19 @@ impl ResultList {
 
 impl Component for ResultList {
     fn render(&mut self, f: &mut Frame, area: Rect) {
+        let truncation_status = if self.list_viewer.is_truncation_enabled() {
+            "Truncated"
+        } else {
+            "Full Text"
+        };
         let layout = ViewLayout::new("Search Results".to_string())
             .with_subtitle(format!(
-                "{} results found | Ctrl+T: Toggle truncation",
-                self.list_viewer.filtered_count()
+                "{} results found | Ctrl+T: Toggle truncation [{}]",
+                self.list_viewer.filtered_count(),
+                truncation_status
             ))
             .with_status_text(
-                "↑/↓ or j/k or Ctrl+P/N: Navigate | Enter: View details | Esc: Exit | ?: Help"
+                "Tab: Filter | ↑/↓ or Ctrl+P/N: Navigate | Enter: Detail | s: Session | Alt+←/→: History | ?: Help | Esc: Exit"
                     .to_string(),
             );
 
@@ -63,14 +69,14 @@ impl Component for ResultList {
 
     fn handle_key(&mut self, key: KeyEvent) -> Option<Message> {
         match key.code {
-            KeyCode::Up | KeyCode::Char('k') => {
+            KeyCode::Up => {
                 if self.list_viewer.move_up() {
                     Some(Message::SelectResult(self.list_viewer.selected_index()))
                 } else {
                     None
                 }
             }
-            KeyCode::Down | KeyCode::Char('j') => {
+            KeyCode::Down => {
                 if self.list_viewer.move_down() {
                     Some(Message::SelectResult(self.list_viewer.selected_index()))
                 } else {
@@ -114,6 +120,20 @@ impl Component for ResultList {
             }
             KeyCode::End => {
                 if self.list_viewer.move_to_end() {
+                    Some(Message::SelectResult(self.list_viewer.selected_index()))
+                } else {
+                    None
+                }
+            }
+            KeyCode::Char('u') if key.modifiers == KeyModifiers::CONTROL => {
+                if self.list_viewer.half_page_up() {
+                    Some(Message::SelectResult(self.list_viewer.selected_index()))
+                } else {
+                    None
+                }
+            }
+            KeyCode::Char('d') if key.modifiers == KeyModifiers::CONTROL => {
+                if self.list_viewer.half_page_down() {
                     Some(Message::SelectResult(self.list_viewer.selected_index()))
                 } else {
                     None

--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -246,7 +246,7 @@ impl Component for SessionViewer {
         // Render status bar
         let status_idx = if self.message.is_some() { 2 } else { 1 };
         if chunks.len() > status_idx {
-            let status_text = "↑/↓ or j/k or Ctrl+P/N: Navigate | Tab: Role Filter | Enter: View Detail | o: Sort | c: Copy JSON | i: Copy Session ID | f: Copy File Path | /: Search | Alt+←/→: History | Esc: Back";
+            let status_text = "↑/↓ or Ctrl+P/N: Navigate | Tab: Role Filter | Enter: View Detail | o: Sort | c: Copy JSON | i: Copy Session ID | f: Copy File Path | /: Search | Alt+←/→: History | Esc: Back";
             let status_bar = Paragraph::new(status_text)
                 .style(Style::default().fg(Color::DarkGray))
                 .alignment(ratatui::layout::Alignment::Center);
@@ -298,11 +298,11 @@ impl Component for SessionViewer {
             }
         } else {
             match key.code {
-                KeyCode::Up | KeyCode::Char('k') => {
+                KeyCode::Up => {
                     self.list_viewer.move_up();
                     Some(Message::SessionNavigated)
                 }
-                KeyCode::Down | KeyCode::Char('j') => {
+                KeyCode::Down => {
                     self.list_viewer.move_down();
                     Some(Message::SessionNavigated)
                 }
@@ -312,6 +312,14 @@ impl Component for SessionViewer {
                 }
                 KeyCode::Char('n') if key.modifiers == KeyModifiers::CONTROL => {
                     self.list_viewer.move_down();
+                    Some(Message::SessionNavigated)
+                }
+                KeyCode::Char('u') if key.modifiers == KeyModifiers::CONTROL => {
+                    self.list_viewer.half_page_up();
+                    Some(Message::SessionNavigated)
+                }
+                KeyCode::Char('d') if key.modifiers == KeyModifiers::CONTROL => {
+                    self.list_viewer.half_page_down();
                     Some(Message::SessionNavigated)
                 }
                 KeyCode::Tab if !key.modifiers.contains(KeyModifiers::CONTROL) => {

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -448,23 +448,6 @@ mod tests {
         assert!(buffer_contains(&buffer, "Session Messages"));
     }
 
-    #[test]
-    fn test_vim_navigation() {
-        let mut viewer = SessionViewer::new();
-        viewer.set_messages(vec![
-            r#"{"type":"user","message":{"content":"message 1"},"timestamp":"2024-01-01T00:00:00Z"}"#.to_string(),
-            r#"{"type":"user","message":{"content":"message 2"},"timestamp":"2024-01-01T00:00:01Z"}"#.to_string(),
-            r#"{"type":"user","message":{"content":"message 3"},"timestamp":"2024-01-01T00:00:02Z"}"#.to_string(),
-        ]);
-
-        // Test down navigation with 'j' - should return SessionNavigated message
-        let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('j'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::SessionNavigated)));
-
-        // Test up navigation with 'k' - should return SessionNavigated message
-        let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('k'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::SessionNavigated)));
-    }
 
     fn create_key_event_with_modifiers(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
         KeyEvent {
@@ -1042,6 +1025,88 @@ mod tests {
         assert!(matches!(msg, Some(Message::SessionNavigated)));
         assert_eq!(viewer.list_viewer.selected_index, 1);
     }
+
+    #[test]
+    fn test_ctrl_u_d_navigation_normal_mode() {
+        let mut viewer = SessionViewer::new();
+        let mut messages = vec![];
+        for i in 0..30 {
+            messages.push(format!(
+                r#"{{"type":"user","message":{{"content":"message {}"}},"timestamp":"2024-01-01T00:00:{:02}Z"}}"#,
+                i + 1, i
+            ));
+        }
+        viewer.set_messages(messages);
+
+        // Initially at index 0
+        assert_eq!(viewer.list_viewer.selected_index, 0);
+
+        // Ctrl+D to move down half page
+        let msg = viewer.handle_key(create_key_event_with_modifiers(
+            KeyCode::Char('d'),
+            KeyModifiers::CONTROL,
+        ));
+        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        // The exact position depends on viewport height, but should have moved down
+        let first_pos = viewer.list_viewer.selected_index;
+        assert!(first_pos > 0);
+
+        // Ctrl+D again
+        let msg = viewer.handle_key(create_key_event_with_modifiers(
+            KeyCode::Char('d'),
+            KeyModifiers::CONTROL,
+        ));
+        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        let second_pos = viewer.list_viewer.selected_index;
+        assert!(second_pos > first_pos);
+
+        // Navigate near the end
+        viewer.list_viewer.selected_index = 25;
+
+        // Ctrl+D should go to last item
+        let msg = viewer.handle_key(create_key_event_with_modifiers(
+            KeyCode::Char('d'),
+            KeyModifiers::CONTROL,
+        ));
+        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        assert_eq!(viewer.list_viewer.selected_index, 29);
+
+        // Can't move down from last item
+        let msg = viewer.handle_key(create_key_event_with_modifiers(
+            KeyCode::Char('d'),
+            KeyModifiers::CONTROL,
+        ));
+        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        assert_eq!(viewer.list_viewer.selected_index, 29);
+
+        // Ctrl+U to move up half page
+        let msg = viewer.handle_key(create_key_event_with_modifiers(
+            KeyCode::Char('u'),
+            KeyModifiers::CONTROL,
+        ));
+        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        assert!(viewer.list_viewer.selected_index < 29);
+
+        // Move to position 5
+        viewer.list_viewer.selected_index = 5;
+
+        // Ctrl+U should go to first item
+        let msg = viewer.handle_key(create_key_event_with_modifiers(
+            KeyCode::Char('u'),
+            KeyModifiers::CONTROL,
+        ));
+        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        assert_eq!(viewer.list_viewer.selected_index, 0);
+
+        // Can't move up from first item
+        let msg = viewer.handle_key(create_key_event_with_modifiers(
+            KeyCode::Char('u'),
+            KeyModifiers::CONTROL,
+        ));
+        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        assert_eq!(viewer.list_viewer.selected_index, 0);
+    }
+
 
     #[test]
     fn test_role_filter_toggle() {

--- a/src/interactive_ratatui/ui/components/view_layout.rs
+++ b/src/interactive_ratatui/ui/components/view_layout.rs
@@ -69,7 +69,7 @@ impl ViewLayout {
         let status_text = self
             .status_text
             .as_deref()
-            .unwrap_or("↑/↓ or j/k: Navigate | Enter: Select | Esc: Back | ?: Help");
+            .unwrap_or("↑/↓: Navigate | Enter: Select | Esc: Back | ?: Help");
 
         let paragraph = Paragraph::new(status_text).wrap(Wrap { trim: true });
 
@@ -150,7 +150,7 @@ impl ViewLayout {
         let status_text = self
             .status_text
             .as_deref()
-            .unwrap_or("↑/↓ or j/k: Navigate | Enter: Select | Esc: Back | ?: Help");
+            .unwrap_or("↑/↓: Navigate | Enter: Select | Esc: Back | ?: Help");
 
         let status_bar = Paragraph::new(status_text)
             .style(Style::default().fg(Color::DarkGray))

--- a/src/interactive_ratatui/ui/components/view_layout_test.rs
+++ b/src/interactive_ratatui/ui/components/view_layout_test.rs
@@ -145,7 +145,7 @@ mod tests {
         let mut terminal = Terminal::new(backend).unwrap();
 
         // Create a long status text that should wrap
-        let long_status = "Tab: Filter | ↑/↓ or j/k or Ctrl+P/N: Navigate | Enter: Detail | s: Session | Alt+←/→: History | ?: Help | Esc: Exit";
+        let long_status = "Tab: Filter | ↑/↓ or Ctrl+P/N: Navigate | Enter: Detail | s: Session | Alt+←/→: History | ?: Help | Esc: Exit";
 
         terminal
             .draw(|f| {
@@ -172,7 +172,7 @@ mod tests {
     fn test_view_layout_status_bar_height_calculation() {
         // Test with various terminal widths
         let widths = vec![30, 50, 80, 120];
-        let long_status = "Tab: Filter | ↑/↓ or j/k or Ctrl+P/N: Navigate | Enter: Detail | s: Session | Alt+←/→: History | ?: Help | Esc: Exit";
+        let long_status = "Tab: Filter | ↑/↓ or Ctrl+P/N: Navigate | Enter: Detail | s: Session | Alt+←/→: History | ?: Help | Esc: Exit";
         
         for width in widths {
             let backend = TestBackend::new(width, 20);

--- a/src/interactive_ratatui/ui/renderer.rs
+++ b/src/interactive_ratatui/ui/renderer.rs
@@ -7,8 +7,6 @@ use crate::interactive_ratatui::ui::components::{
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout},
-    style::{Color, Style},
-    widgets::Paragraph,
 };
 
 #[derive(Default)]
@@ -46,7 +44,6 @@ impl Renderer {
             .constraints([
                 Constraint::Length(SEARCH_BAR_HEIGHT), // Search bar
                 Constraint::Min(0),                    // Results
-                Constraint::Length(STATUS_BAR_HEIGHT), // Status bar
             ])
             .split(f.area());
 
@@ -67,18 +64,6 @@ impl Renderer {
         // Render components
         self.search_bar.render(f, chunks[0]);
         self.result_list.render(f, chunks[1]);
-
-        // Render status bar
-        let truncation_status = if state.ui.truncation_enabled {
-            "Truncated"
-        } else {
-            "Full Text"
-        };
-        let status_text = format!(
-            "Tab: Filter | ↑/↓: Navigate | Enter: Detail | s: Session | Alt+←/→: History | Ctrl+T: Toggle [{truncation_status}] | ?: Help | Esc: Exit"
-        );
-        let status_bar = Paragraph::new(status_text).style(Style::default().fg(Color::DarkGray));
-        f.render_widget(status_bar, chunks[2]);
     }
 
     fn render_detail_mode(&mut self, f: &mut Frame, state: &AppState) {


### PR DESCRIPTION
## Summary
This PR adds vim-style half-page scrolling functionality and removes j/k navigation from the interactive TUI mode.

## Changes
### Added
- **Half-page scrolling with Ctrl+u/d**: Implemented vim-style half-page up/down scrolling in search results and session viewer
  - Added `half_page_up()` and `half_page_down()` methods to `ListViewer` component
  - Scrolling distance is dynamically calculated based on viewport height
  - Works consistently across different terminal sizes

### Removed
- **j/k navigation**: Removed vim j/k key bindings from all components
  - Removed from `ResultList`, `SessionViewer`, and `ResultDetail` components
  - Updated all help texts and status bars to reflect the change
  - Maintains arrow keys and Ctrl+P/N for navigation

### Fixed
- Fixed clippy warning about using `clamp()` instead of manual min/max
- Fixed duplicate status bar rendering issue
- Added text wrapping support for long status bar text

## Testing
- Added comprehensive tests for half-page scrolling functionality
- Updated existing tests to remove j/k navigation assertions
- All tests pass successfully
- No clippy warnings

## Technical Details
The half-page scrolling implementation tracks the viewport height during rendering and calculates scroll distance as `viewport_height / 2`. This ensures consistent behavior regardless of terminal size, matching vim's behavior.

Closes #116 (if applicable)