### PR TITLE
Refactor: Use enum for copy content tracking and improve feedback messages

### DIFF
--- a/src/interactive_ratatui/integration_tests.rs
+++ b/src/interactive_ratatui/integration_tests.rs
@@ -599,7 +599,9 @@ mod tests {
         let mut app = InteractiveSearch::new(SearchOptions::default());
 
         // Test file path copy feedback
-        app.execute_command(Command::CopyToClipboard(CopyContent::FilePath("/path/to/file.jsonl".to_string())));
+        app.execute_command(Command::CopyToClipboard(CopyContent::FilePath(
+            "/path/to/file.jsonl".to_string(),
+        )));
         // In CI environment, clipboard might fail
         if let Some(msg) = &app.state.ui.message {
             assert!(
@@ -622,7 +624,9 @@ mod tests {
 
         // Test short text copy feedback
         app.state.ui.message = None;
-        app.execute_command(Command::CopyToClipboard(CopyContent::MessageContent("short text".to_string())));
+        app.execute_command(Command::CopyToClipboard(CopyContent::MessageContent(
+            "short text".to_string(),
+        )));
         if let Some(msg) = &app.state.ui.message {
             assert!(
                 msg == "✓ Copied: short text" || msg.starts_with("Failed to copy:"),
@@ -633,7 +637,9 @@ mod tests {
         // Test long message copy feedback
         app.state.ui.message = None;
         let long_text = "a".repeat(200);
-        app.execute_command(Command::CopyToClipboard(CopyContent::MessageContent(long_text)));
+        app.execute_command(Command::CopyToClipboard(CopyContent::MessageContent(
+            long_text,
+        )));
         if let Some(msg) = &app.state.ui.message {
             assert!(
                 msg == "✓ Copied message text" || msg.starts_with("Failed to copy:"),
@@ -819,7 +825,9 @@ mod tests {
         let mut app = InteractiveSearch::new(SearchOptions::default());
 
         // Execute copy command to show message
-        app.execute_command(Command::CopyToClipboard(CopyContent::SessionId("test-id-1234".to_string())));
+        app.execute_command(Command::CopyToClipboard(CopyContent::SessionId(
+            "test-id-1234".to_string(),
+        )));
 
         // Message should be displayed
         assert!(app.state.ui.message.is_some());

--- a/src/interactive_ratatui/integration_tests.rs
+++ b/src/interactive_ratatui/integration_tests.rs
@@ -2,7 +2,7 @@
 mod tests {
     use super::super::*;
     use crate::interactive_ratatui::domain::models::Mode;
-    use crate::interactive_ratatui::ui::events::Message;
+    use crate::interactive_ratatui::ui::events::{CopyContent, Message};
     use crate::interactive_ratatui::ui::navigation::{
         NavigationHistory, NavigationState, SearchStateSnapshot, SessionStateSnapshot,
         UiStateSnapshot,
@@ -599,7 +599,7 @@ mod tests {
         let mut app = InteractiveSearch::new(SearchOptions::default());
 
         // Test file path copy feedback
-        app.execute_command(Command::CopyToClipboard("/path/to/file.jsonl".to_string()));
+        app.execute_command(Command::CopyToClipboard(CopyContent::FilePath("/path/to/file.jsonl".to_string())));
         // In CI environment, clipboard might fail
         if let Some(msg) = &app.state.ui.message {
             assert!(
@@ -610,9 +610,9 @@ mod tests {
 
         // Test session ID copy feedback
         app.state.ui.message = None;
-        app.execute_command(Command::CopyToClipboard(
+        app.execute_command(Command::CopyToClipboard(CopyContent::SessionId(
             "12345678-1234-5678-1234-567812345678".to_string(),
-        ));
+        )));
         if let Some(msg) = &app.state.ui.message {
             assert!(
                 msg == "✓ Copied session ID" || msg.starts_with("Failed to copy:"),
@@ -622,7 +622,7 @@ mod tests {
 
         // Test short text copy feedback
         app.state.ui.message = None;
-        app.execute_command(Command::CopyToClipboard("short text".to_string()));
+        app.execute_command(Command::CopyToClipboard(CopyContent::MessageContent("short text".to_string())));
         if let Some(msg) = &app.state.ui.message {
             assert!(
                 msg == "✓ Copied: short text" || msg.starts_with("Failed to copy:"),
@@ -633,7 +633,7 @@ mod tests {
         // Test long message copy feedback
         app.state.ui.message = None;
         let long_text = "a".repeat(200);
-        app.execute_command(Command::CopyToClipboard(long_text));
+        app.execute_command(Command::CopyToClipboard(CopyContent::MessageContent(long_text)));
         if let Some(msg) = &app.state.ui.message {
             assert!(
                 msg == "✓ Copied message text" || msg.starts_with("Failed to copy:"),
@@ -759,8 +759,8 @@ mod tests {
             ('F', "✓ Copied file path"),
             ('i', "✓ Copied session ID"),
             ('I', "✓ Copied session ID"),
-            ('p', "✓ Copied file path"), // project path
-            ('P', "✓ Copied file path"),
+            ('p', "✓ Copied project path"), // project path
+            ('P', "✓ Copied project path"),
             ('m', "✓ Copied: Test message"), // short text shows the actual text
             ('M', "✓ Copied: Test message"),
         ];
@@ -819,7 +819,7 @@ mod tests {
         let mut app = InteractiveSearch::new(SearchOptions::default());
 
         // Execute copy command to show message
-        app.execute_command(Command::CopyToClipboard("test-id-1234".to_string()));
+        app.execute_command(Command::CopyToClipboard(CopyContent::SessionId("test-id-1234".to_string())));
 
         // Message should be displayed
         assert!(app.state.ui.message.is_some());

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -255,26 +255,27 @@ impl InteractiveSearch {
             Command::LoadSession(file_path) => {
                 self.load_session_messages(&file_path);
             }
-            Command::CopyToClipboard(text) => {
+            Command::CopyToClipboard(content) => {
+                let (text, copy_message) = match content {
+                    ui::events::CopyContent::FilePath(path) => (path, "✓ Copied file path".to_string()),
+                    ui::events::CopyContent::ProjectPath(path) => (path, "✓ Copied project path".to_string()),
+                    ui::events::CopyContent::SessionId(id) => (id, "✓ Copied session ID".to_string()),
+                    ui::events::CopyContent::MessageContent(msg) => {
+                        let message = if msg.len() < 100 {
+                            format!("✓ Copied: {}", msg.chars().take(50).collect::<String>())
+                        } else {
+                            "✓ Copied message text".to_string()
+                        };
+                        (msg, message)
+                    }
+                    ui::events::CopyContent::JsonData(json) => (json, "✓ Copied JSON data".to_string()),
+                    ui::events::CopyContent::FullResultDetails(details) => (details, "✓ Copied full result details".to_string()),
+                };
+
                 if let Err(e) = self.copy_to_clipboard(&text) {
                     self.state.ui.message = Some(format!("Failed to copy: {e}"));
                 } else {
-                    // Determine what was copied for better feedback
-                    let copy_message = if text.starts_with("File: ") && text.contains("\nUUID: ") {
-                        "✓ Copied full result details"
-                    } else if text.starts_with('/')
-                        && (text.ends_with(".jsonl") || text.contains('/'))
-                    {
-                        "✓ Copied file path"
-                    } else if text.len() == 36 && text.chars().filter(|&c| c == '-').count() == 4 {
-                        // UUID format check
-                        "✓ Copied session ID"
-                    } else if text.len() < 100 {
-                        &format!("✓ Copied: {}", text.chars().take(50).collect::<String>())
-                    } else {
-                        "✓ Copied message text"
-                    };
-                    self.state.ui.message = Some(copy_message.to_string());
+                    self.state.ui.message = Some(copy_message);
 
                     // Schedule message clear after delay
                     self.message_timer = Some(std::time::Instant::now());

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -257,9 +257,15 @@ impl InteractiveSearch {
             }
             Command::CopyToClipboard(content) => {
                 let (text, copy_message) = match content {
-                    ui::events::CopyContent::FilePath(path) => (path, "✓ Copied file path".to_string()),
-                    ui::events::CopyContent::ProjectPath(path) => (path, "✓ Copied project path".to_string()),
-                    ui::events::CopyContent::SessionId(id) => (id, "✓ Copied session ID".to_string()),
+                    ui::events::CopyContent::FilePath(path) => {
+                        (path, "✓ Copied file path".to_string())
+                    }
+                    ui::events::CopyContent::ProjectPath(path) => {
+                        (path, "✓ Copied project path".to_string())
+                    }
+                    ui::events::CopyContent::SessionId(id) => {
+                        (id, "✓ Copied session ID".to_string())
+                    }
                     ui::events::CopyContent::MessageContent(msg) => {
                         let message = if msg.len() < 100 {
                             format!("✓ Copied: {}", msg.chars().take(50).collect::<String>())
@@ -268,8 +274,12 @@ impl InteractiveSearch {
                         };
                         (msg, message)
                     }
-                    ui::events::CopyContent::JsonData(json) => (json, "✓ Copied JSON data".to_string()),
-                    ui::events::CopyContent::FullResultDetails(details) => (details, "✓ Copied full result details".to_string()),
+                    ui::events::CopyContent::JsonData(json) => {
+                        (json, "✓ Copied JSON data".to_string())
+                    }
+                    ui::events::CopyContent::FullResultDetails(details) => {
+                        (details, "✓ Copied full result details".to_string())
+                    }
                 };
 
                 if let Err(e) = self.copy_to_clipboard(&text) {

--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -423,7 +423,7 @@ impl AppState {
                 }
                 Command::None
             }
-            Message::CopyToClipboard(text) => Command::CopyToClipboard(text),
+            Message::CopyToClipboard(content) => Command::CopyToClipboard(content),
             Message::Quit => {
                 Command::None // Handle in main loop
             }

--- a/src/interactive_ratatui/ui/app_state_test.rs
+++ b/src/interactive_ratatui/ui/app_state_test.rs
@@ -157,9 +157,13 @@ mod tests {
         let mut state = create_test_state();
         let text = "Copy this text".to_string();
 
-        let command = state.update(Message::CopyToClipboard(CopyContent::MessageContent(text.clone())));
+        let command = state.update(Message::CopyToClipboard(CopyContent::MessageContent(
+            text.clone(),
+        )));
 
-        assert!(matches!(command, Command::CopyToClipboard(CopyContent::MessageContent(t)) if t == text));
+        assert!(
+            matches!(command, Command::CopyToClipboard(CopyContent::MessageContent(t)) if t == text)
+        );
     }
 
     #[test]

--- a/src/interactive_ratatui/ui/app_state_test.rs
+++ b/src/interactive_ratatui/ui/app_state_test.rs
@@ -2,7 +2,7 @@
 mod tests {
     use super::super::app_state::*;
     use super::super::commands::Command;
-    use super::super::events::Message;
+    use super::super::events::{CopyContent, Message};
     use crate::query::condition::{QueryCondition, SearchResult};
 
     fn create_test_state() -> AppState {
@@ -157,9 +157,9 @@ mod tests {
         let mut state = create_test_state();
         let text = "Copy this text".to_string();
 
-        let command = state.update(Message::CopyToClipboard(text.clone()));
+        let command = state.update(Message::CopyToClipboard(CopyContent::MessageContent(text.clone())));
 
-        assert!(matches!(command, Command::CopyToClipboard(t) if t == text));
+        assert!(matches!(command, Command::CopyToClipboard(CopyContent::MessageContent(t)) if t == text));
     }
 
     #[test]

--- a/src/interactive_ratatui/ui/commands.rs
+++ b/src/interactive_ratatui/ui/commands.rs
@@ -1,10 +1,12 @@
+use super::events::CopyContent;
+
 #[derive(Clone, Debug)]
 pub enum Command {
     None,
     ExecuteSearch,
     ScheduleSearch(u64), // delay in milliseconds
     LoadSession(String),
-    CopyToClipboard(String),
+    CopyToClipboard(CopyContent),
     ShowMessage(String),
     ClearMessage,
     ScheduleClearMessage(u64), // delay in milliseconds

--- a/src/interactive_ratatui/ui/components/result_detail.rs
+++ b/src/interactive_ratatui/ui/components/result_detail.rs
@@ -2,7 +2,7 @@ use crate::interactive_ratatui::ui::components::{
     Component,
     view_layout::{Styles, ViewLayout},
 };
-use crate::interactive_ratatui::ui::events::Message;
+use crate::interactive_ratatui::ui::events::{CopyContent, Message};
 use crate::query::condition::SearchResult;
 use crossterm::event::{KeyCode, KeyEvent};
 use ratatui::{
@@ -249,23 +249,23 @@ impl Component for ResultDetail {
             KeyCode::Char('f') | KeyCode::Char('F') => self
                 .result
                 .as_ref()
-                .map(|result| Message::CopyToClipboard(result.file.clone())),
+                .map(|result| Message::CopyToClipboard(CopyContent::FilePath(result.file.clone()))),
             KeyCode::Char('i') | KeyCode::Char('I') => self
                 .result
                 .as_ref()
-                .map(|result| Message::CopyToClipboard(result.session_id.clone())),
+                .map(|result| Message::CopyToClipboard(CopyContent::SessionId(result.session_id.clone()))),
             KeyCode::Char('p') | KeyCode::Char('P') => self
                 .result
                 .as_ref()
-                .map(|result| Message::CopyToClipboard(result.project_path.clone())),
+                .map(|result| Message::CopyToClipboard(CopyContent::ProjectPath(result.project_path.clone()))),
             KeyCode::Char('m') | KeyCode::Char('M') => self
                 .result
                 .as_ref()
-                .map(|result| Message::CopyToClipboard(result.text.clone())),
+                .map(|result| Message::CopyToClipboard(CopyContent::MessageContent(result.text.clone()))),
             KeyCode::Char('r') | KeyCode::Char('R') => {
                 if let Some(result) = &self.result {
                     if let Some(raw_json) = &result.raw_json {
-                        Some(Message::CopyToClipboard(raw_json.clone()))
+                        Some(Message::CopyToClipboard(CopyContent::JsonData(raw_json.clone())))
                     } else {
                         let formatted = format!(
                             "File: {}\nUUID: {}\nTimestamp: {}\nSession ID: {}\nRole: {}\nText: {}\nProject: {}",
@@ -277,7 +277,7 @@ impl Component for ResultDetail {
                             result.text,
                             result.project_path
                         );
-                        Some(Message::CopyToClipboard(formatted))
+                        Some(Message::CopyToClipboard(CopyContent::FullResultDetails(formatted)))
                     }
                 } else {
                     None
@@ -286,7 +286,7 @@ impl Component for ResultDetail {
             KeyCode::Char('c') | KeyCode::Char('C') => self
                 .result
                 .as_ref()
-                .map(|result| Message::CopyToClipboard(result.text.clone())),
+                .map(|result| Message::CopyToClipboard(CopyContent::MessageContent(result.text.clone()))),
             KeyCode::Esc => Some(Message::ExitToSearch),
             _ => None,
         }

--- a/src/interactive_ratatui/ui/components/result_detail.rs
+++ b/src/interactive_ratatui/ui/components/result_detail.rs
@@ -250,22 +250,21 @@ impl Component for ResultDetail {
                 .result
                 .as_ref()
                 .map(|result| Message::CopyToClipboard(CopyContent::FilePath(result.file.clone()))),
-            KeyCode::Char('i') | KeyCode::Char('I') => self
-                .result
-                .as_ref()
-                .map(|result| Message::CopyToClipboard(CopyContent::SessionId(result.session_id.clone()))),
-            KeyCode::Char('p') | KeyCode::Char('P') => self
-                .result
-                .as_ref()
-                .map(|result| Message::CopyToClipboard(CopyContent::ProjectPath(result.project_path.clone()))),
-            KeyCode::Char('m') | KeyCode::Char('M') => self
-                .result
-                .as_ref()
-                .map(|result| Message::CopyToClipboard(CopyContent::MessageContent(result.text.clone()))),
+            KeyCode::Char('i') | KeyCode::Char('I') => self.result.as_ref().map(|result| {
+                Message::CopyToClipboard(CopyContent::SessionId(result.session_id.clone()))
+            }),
+            KeyCode::Char('p') | KeyCode::Char('P') => self.result.as_ref().map(|result| {
+                Message::CopyToClipboard(CopyContent::ProjectPath(result.project_path.clone()))
+            }),
+            KeyCode::Char('m') | KeyCode::Char('M') => self.result.as_ref().map(|result| {
+                Message::CopyToClipboard(CopyContent::MessageContent(result.text.clone()))
+            }),
             KeyCode::Char('r') | KeyCode::Char('R') => {
                 if let Some(result) = &self.result {
                     if let Some(raw_json) = &result.raw_json {
-                        Some(Message::CopyToClipboard(CopyContent::JsonData(raw_json.clone())))
+                        Some(Message::CopyToClipboard(CopyContent::JsonData(
+                            raw_json.clone(),
+                        )))
                     } else {
                         let formatted = format!(
                             "File: {}\nUUID: {}\nTimestamp: {}\nSession ID: {}\nRole: {}\nText: {}\nProject: {}",
@@ -277,16 +276,17 @@ impl Component for ResultDetail {
                             result.text,
                             result.project_path
                         );
-                        Some(Message::CopyToClipboard(CopyContent::FullResultDetails(formatted)))
+                        Some(Message::CopyToClipboard(CopyContent::FullResultDetails(
+                            formatted,
+                        )))
                     }
                 } else {
                     None
                 }
             }
-            KeyCode::Char('c') | KeyCode::Char('C') => self
-                .result
-                .as_ref()
-                .map(|result| Message::CopyToClipboard(CopyContent::MessageContent(result.text.clone()))),
+            KeyCode::Char('c') | KeyCode::Char('C') => self.result.as_ref().map(|result| {
+                Message::CopyToClipboard(CopyContent::MessageContent(result.text.clone()))
+            }),
             KeyCode::Esc => Some(Message::ExitToSearch),
             _ => None,
         }

--- a/src/interactive_ratatui/ui/components/result_detail_test.rs
+++ b/src/interactive_ratatui/ui/components/result_detail_test.rs
@@ -259,11 +259,15 @@ mod tests {
 
         // Test copy session ID (I)
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123"));
+        assert!(
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123")
+        );
 
         // Test copy project path (P)
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::ProjectPath(path))) if path == "/path/to/project"));
+        assert!(
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::ProjectPath(path))) if path == "/path/to/project")
+        );
 
         // Test copy message text (M)
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::empty()));
@@ -273,7 +277,9 @@ mod tests {
 
         // Test copy raw JSON (R)
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::JsonData(json))) if json.contains("user")));
+        assert!(
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::JsonData(json))) if json.contains("user"))
+        );
 
         // Test copy with 'c' (should copy message text)
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty()));
@@ -387,7 +393,9 @@ mod tests {
         );
 
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('I'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123"));
+        assert!(
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123")
+        );
 
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('S'), KeyModifiers::empty()));
         assert!(matches!(msg, Some(Message::EnterSessionViewer)));

--- a/src/interactive_ratatui/ui/components/result_detail_test.rs
+++ b/src/interactive_ratatui/ui/components/result_detail_test.rs
@@ -2,7 +2,7 @@
 mod tests {
     use super::super::result_detail::ResultDetail;
     use crate::interactive_ratatui::ui::components::Component;
-    use crate::interactive_ratatui::ui::events::Message;
+    use crate::interactive_ratatui::ui::events::{CopyContent, Message};
     use crate::query::condition::{QueryCondition, SearchResult};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
@@ -254,31 +254,31 @@ mod tests {
         // Test copy file path (F)
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::empty()));
         assert!(
-            matches!(msg, Some(Message::CopyToClipboard(text)) if text == "/path/to/test.jsonl")
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::FilePath(path))) if path == "/path/to/test.jsonl")
         );
 
         // Test copy session ID (I)
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(text)) if text == "session-123"));
+        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123"));
 
         // Test copy project path (P)
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(text)) if text == "/path/to/project"));
+        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::ProjectPath(path))) if path == "/path/to/project"));
 
         // Test copy message text (M)
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('m'), KeyModifiers::empty()));
         assert!(
-            matches!(msg, Some(Message::CopyToClipboard(text)) if text == "This is a test message")
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::MessageContent(text))) if text == "This is a test message")
         );
 
         // Test copy raw JSON (R)
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(text)) if text.contains("user")));
+        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::JsonData(json))) if json.contains("user")));
 
         // Test copy with 'c' (should copy message text)
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty()));
         assert!(
-            matches!(msg, Some(Message::CopyToClipboard(text)) if text == "This is a test message")
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::MessageContent(text))) if text == "This is a test message")
         );
     }
 
@@ -383,11 +383,11 @@ mod tests {
         // Test uppercase variants of shortcuts
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('F'), KeyModifiers::empty()));
         assert!(
-            matches!(msg, Some(Message::CopyToClipboard(text)) if text == "/path/to/test.jsonl")
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::FilePath(path))) if path == "/path/to/test.jsonl")
         );
 
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('I'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(text)) if text == "session-123"));
+        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123"));
 
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('S'), KeyModifiers::empty()));
         assert!(matches!(msg, Some(Message::EnterSessionViewer)));
@@ -418,13 +418,18 @@ mod tests {
 
         // Should create a formatted string when raw_json is None
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('r'), KeyModifiers::empty()));
-        if let Some(Message::CopyToClipboard(text)) = msg {
-            assert!(text.contains("File: /path/to/test.jsonl"));
-            assert!(text.contains("UUID: 12345678-1234-5678-1234-567812345678"));
-            assert!(text.contains("Session ID: session-123"));
-            assert!(text.contains("Role: user"));
-            assert!(text.contains("Text: This is a test message"));
-            assert!(text.contains("Project: /path/to/project"));
+        if let Some(Message::CopyToClipboard(content)) = msg {
+            match content {
+                CopyContent::FullResultDetails(text) => {
+                    assert!(text.contains("File: /path/to/test.jsonl"));
+                    assert!(text.contains("UUID: 12345678-1234-5678-1234-567812345678"));
+                    assert!(text.contains("Session ID: session-123"));
+                    assert!(text.contains("Role: user"));
+                    assert!(text.contains("Text: This is a test message"));
+                    assert!(text.contains("Project: /path/to/project"));
+                }
+                _ => panic!("Expected FullResultDetails variant"),
+            }
         } else {
             panic!("Expected CopyToClipboard message");
         }

--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -150,12 +150,12 @@ impl SessionViewer {
         // Extract project path from file path
         // Format: ~/.claude/projects/{encoded-project-path}/{session-id}.jsonl
         let path = Path::new(file_path);
-        
+
         // Check if this is a Claude project path
         if !file_path.contains(".claude/projects/") {
             return None;
         }
-        
+
         if let Some(parent) = path.parent() {
             if let Some(project_name) = parent.file_name() {
                 if let Some(project_str) = project_name.to_str() {
@@ -219,19 +219,19 @@ impl SessionViewer {
 impl Component for SessionViewer {
     fn render(&mut self, f: &mut Frame, area: Rect) {
         let mut subtitle_parts = Vec::new();
-        
+
         if let Some(project) = &self.project_path {
             subtitle_parts.push(format!("Project: {project}"));
         }
-        
+
         if let Some(session) = &self.session_id {
             subtitle_parts.push(format!("Session: {session}"));
         }
-        
+
         if let Some(file) = &self.file_path {
             subtitle_parts.push(format!("File: {file}"));
         }
-        
+
         let subtitle = subtitle_parts.join("\n");
 
         // Layout with message area
@@ -360,28 +360,33 @@ impl Component for SessionViewer {
                     None
                 }
                 KeyCode::Char('o') => Some(Message::ToggleSessionOrder),
-                KeyCode::Char('c') => self
-                    .list_viewer
-                    .get_selected_item()
-                    .map(|item| Message::CopyToClipboard(CopyContent::JsonData(item.raw_json.clone()))),
+                KeyCode::Char('c') => self.list_viewer.get_selected_item().map(|item| {
+                    Message::CopyToClipboard(CopyContent::JsonData(item.raw_json.clone()))
+                }),
                 KeyCode::Char('C') => {
                     // Copy all raw messages for now
                     // TODO: Add method to ListViewer to get filtered items
-                    Some(Message::CopyToClipboard(CopyContent::JsonData(self.raw_messages.join("\n\n"))))
+                    Some(Message::CopyToClipboard(CopyContent::JsonData(
+                        self.raw_messages.join("\n\n"),
+                    )))
                 }
-                KeyCode::Char('i') | KeyCode::Char('I') => {
-                    self.session_id.clone().map(|id| Message::CopyToClipboard(CopyContent::SessionId(id)))
+                KeyCode::Char('i') | KeyCode::Char('I') => self
+                    .session_id
+                    .clone()
+                    .map(|id| Message::CopyToClipboard(CopyContent::SessionId(id))),
+                KeyCode::Char('p') | KeyCode::Char('P') => self
+                    .project_path
+                    .clone()
+                    .map(|path| Message::CopyToClipboard(CopyContent::ProjectPath(path))),
+                KeyCode::Char('f') | KeyCode::Char('F') => self
+                    .file_path
+                    .clone()
+                    .map(|path| Message::CopyToClipboard(CopyContent::FilePath(path))),
+                KeyCode::Char('m') | KeyCode::Char('M') => {
+                    self.list_viewer.get_selected_item().map(|item| {
+                        Message::CopyToClipboard(CopyContent::MessageContent(item.content.clone()))
+                    })
                 }
-                KeyCode::Char('p') | KeyCode::Char('P') => {
-                    self.project_path.clone().map(|path| Message::CopyToClipboard(CopyContent::ProjectPath(path)))
-                }
-                KeyCode::Char('f') | KeyCode::Char('F') => {
-                    self.file_path.clone().map(|path| Message::CopyToClipboard(CopyContent::FilePath(path)))
-                }
-                KeyCode::Char('m') | KeyCode::Char('M') => self
-                    .list_viewer
-                    .get_selected_item()
-                    .map(|item| Message::CopyToClipboard(CopyContent::MessageContent(item.content.clone()))),
                 KeyCode::Enter => self.list_viewer.get_selected_item().and_then(|item| {
                     self.file_path.as_ref().map(|path| {
                         Message::EnterResultDetailFromSession(

--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -6,7 +6,7 @@ use crate::interactive_ratatui::ui::components::{
     text_input::TextInput,
     view_layout::{ColorScheme, ViewLayout},
 };
-use crate::interactive_ratatui::ui::events::Message;
+use crate::interactive_ratatui::ui::events::{CopyContent, Message};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::{
     Frame,
@@ -17,6 +17,7 @@ use ratatui::{
 };
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
+use std::path::Path;
 
 #[derive(Default)]
 pub struct SessionViewer {
@@ -29,6 +30,7 @@ pub struct SessionViewer {
     order: Option<SessionOrder>,
     is_searching: bool,
     file_path: Option<String>,
+    project_path: Option<String>,
     session_id: Option<String>,
     messages_hash: u64,
     message: Option<String>,
@@ -47,6 +49,7 @@ impl SessionViewer {
             order: None,
             is_searching: false,
             file_path: None,
+            project_path: None,
             session_id: None,
             messages_hash: 0,
             message: None,
@@ -90,7 +93,9 @@ impl SessionViewer {
     }
 
     pub fn set_file_path(&mut self, file_path: Option<String>) {
-        self.file_path = file_path;
+        self.file_path = file_path.clone();
+        // Extract project path from file path
+        self.project_path = file_path.and_then(|path| Self::extract_project_path(&path));
     }
 
     pub fn set_session_id(&mut self, session_id: Option<String>) {
@@ -141,6 +146,30 @@ impl SessionViewer {
         self.text_input.text()
     }
 
+    fn extract_project_path(file_path: &str) -> Option<String> {
+        // Extract project path from file path
+        // Format: ~/.claude/projects/{encoded-project-path}/{session-id}.jsonl
+        let path = Path::new(file_path);
+        
+        // Check if this is a Claude project path
+        if !file_path.contains(".claude/projects/") {
+            return None;
+        }
+        
+        if let Some(parent) = path.parent() {
+            if let Some(project_name) = parent.file_name() {
+                if let Some(project_str) = project_name.to_str() {
+                    // Decode the project path (replace hyphens with slashes)
+                    let decoded = project_str.replace('-', "/");
+                    if !decoded.is_empty() && decoded != "/" {
+                        return Some(decoded);
+                    }
+                }
+            }
+        }
+        None
+    }
+
     fn render_content(&mut self, f: &mut Frame, area: Rect) {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
@@ -189,12 +218,21 @@ impl SessionViewer {
 
 impl Component for SessionViewer {
     fn render(&mut self, f: &mut Frame, area: Rect) {
-        let subtitle = match (&self.session_id, &self.file_path) {
-            (Some(session), Some(file)) => format!("Session: {session}\nFile: {file}"),
-            (Some(session), None) => format!("Session: {session}"),
-            (None, Some(file)) => format!("File: {file}"),
-            (None, None) => String::new(),
-        };
+        let mut subtitle_parts = Vec::new();
+        
+        if let Some(project) = &self.project_path {
+            subtitle_parts.push(format!("Project: {project}"));
+        }
+        
+        if let Some(session) = &self.session_id {
+            subtitle_parts.push(format!("Session: {session}"));
+        }
+        
+        if let Some(file) = &self.file_path {
+            subtitle_parts.push(format!("File: {file}"));
+        }
+        
+        let subtitle = subtitle_parts.join("\n");
 
         // Layout with message area
         let chunks = if self.message.is_some() {
@@ -246,7 +284,7 @@ impl Component for SessionViewer {
         // Render status bar
         let status_idx = if self.message.is_some() { 2 } else { 1 };
         if chunks.len() > status_idx {
-            let status_text = "↑/↓ or j/k or Ctrl+P/N: Navigate | Tab: Role Filter | Enter: View Detail | o: Sort | c: Copy JSON | i: Copy Session ID | f: Copy File Path | /: Search | Alt+←/→: History | Esc: Back";
+            let status_text = "↑/↓ or j/k or Ctrl+P/N: Navigate | Tab: Role Filter | Enter: View Detail | o: Sort | c: Copy JSON | i: Copy Session ID | p: Copy Project Path | f: Copy File Path | /: Search | Alt+←/→: History | Esc: Back";
             let status_bar = Paragraph::new(status_text)
                 .style(Style::default().fg(Color::DarkGray))
                 .alignment(ratatui::layout::Alignment::Center);
@@ -325,22 +363,25 @@ impl Component for SessionViewer {
                 KeyCode::Char('c') => self
                     .list_viewer
                     .get_selected_item()
-                    .map(|item| Message::CopyToClipboard(item.raw_json.clone())),
+                    .map(|item| Message::CopyToClipboard(CopyContent::JsonData(item.raw_json.clone()))),
                 KeyCode::Char('C') => {
                     // Copy all raw messages for now
                     // TODO: Add method to ListViewer to get filtered items
-                    Some(Message::CopyToClipboard(self.raw_messages.join("\n\n")))
+                    Some(Message::CopyToClipboard(CopyContent::JsonData(self.raw_messages.join("\n\n"))))
                 }
                 KeyCode::Char('i') | KeyCode::Char('I') => {
-                    self.session_id.clone().map(Message::CopyToClipboard)
+                    self.session_id.clone().map(|id| Message::CopyToClipboard(CopyContent::SessionId(id)))
+                }
+                KeyCode::Char('p') | KeyCode::Char('P') => {
+                    self.project_path.clone().map(|path| Message::CopyToClipboard(CopyContent::ProjectPath(path)))
                 }
                 KeyCode::Char('f') | KeyCode::Char('F') => {
-                    self.file_path.clone().map(Message::CopyToClipboard)
+                    self.file_path.clone().map(|path| Message::CopyToClipboard(CopyContent::FilePath(path)))
                 }
                 KeyCode::Char('m') | KeyCode::Char('M') => self
                     .list_viewer
                     .get_selected_item()
-                    .map(|item| Message::CopyToClipboard(item.content.clone())),
+                    .map(|item| Message::CopyToClipboard(CopyContent::MessageContent(item.content.clone()))),
                 KeyCode::Enter => self.list_viewer.get_selected_item().and_then(|item| {
                     self.file_path.as_ref().map(|path| {
                         Message::EnterResultDetailFromSession(

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -3,7 +3,7 @@ mod tests {
     use super::super::session_viewer::SessionViewer;
     use crate::interactive_ratatui::domain::models::SessionOrder;
     use crate::interactive_ratatui::ui::components::Component;
-    use crate::interactive_ratatui::ui::events::Message;
+    use crate::interactive_ratatui::ui::events::{CopyContent, Message};
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ratatui::{Terminal, backend::TestBackend, buffer::Buffer};
 
@@ -256,31 +256,83 @@ mod tests {
 
         // Test copy single message
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(_))));
+        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::JsonData(_)))));
 
         // Test copy all messages
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('C'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(_))));
+        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::JsonData(_)))));
 
         // Test copy session ID
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(id)) if id == "session-123"));
+        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123"));
 
         // Test copy session ID with uppercase
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('I'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(id)) if id == "session-123"));
+        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123"));
 
         // Test copy file path
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::empty()));
         assert!(
-            matches!(msg, Some(Message::CopyToClipboard(path)) if path == "/path/to/session.jsonl")
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::FilePath(path))) if path == "/path/to/session.jsonl")
         );
 
         // Test copy file path with uppercase
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('F'), KeyModifiers::empty()));
         assert!(
-            matches!(msg, Some(Message::CopyToClipboard(path)) if path == "/path/to/session.jsonl")
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::FilePath(path))) if path == "/path/to/session.jsonl")
         );
+    }
+
+    #[test]
+    fn test_copy_project_path() {
+        let mut viewer = SessionViewer::new();
+        viewer.set_messages(vec![
+            r#"{"type":"user","message":{"content":"test"}}"#.to_string(),
+        ]);
+        viewer.set_file_path(Some("/Users/masatomokusaka/.claude/projects/-Users-project-name/session.jsonl".to_string()));
+
+        // Test copy project path
+        let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::empty()));
+        assert!(
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::ProjectPath(path))) if path == "/Users/project/name")
+        );
+
+        // Test copy project path with uppercase
+        let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('P'), KeyModifiers::empty()));
+        assert!(
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::ProjectPath(path))) if path == "/Users/project/name")
+        );
+    }
+
+    #[test]
+    fn test_copy_project_path_without_path() {
+        let mut viewer = SessionViewer::new();
+
+        // No project path set (no file path)
+        let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::empty()));
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn test_extract_project_path() {
+        let mut viewer = SessionViewer::new();
+        
+        // Test with typical Claude project path
+        viewer.set_file_path(Some("/Users/masatomokusaka/.claude/projects/-Users-masatomokusaka-src-github-com-clerk-clerk-playwright-nextjs/fb101a01-0e24-4a45-9e42-74117ebc20e6.jsonl".to_string()));
+        
+        let buffer = render_component(&mut viewer, 180, 24);
+        assert!(buffer_contains(&buffer, "Project: /Users/masatomokusaka/src/github/com/clerk/clerk/playwright/nextjs"));
+        
+        // Test with shorter path
+        viewer.set_file_path(Some("/home/user/.claude/projects/-tmp-test/session.jsonl".to_string()));
+        let buffer = render_component(&mut viewer, 100, 24);
+        assert!(buffer_contains(&buffer, "Project: /tmp/test"));
+        
+        // Test with no project path (invalid format)
+        viewer.set_file_path(Some("/invalid/path/file.jsonl".to_string()));
+        let buffer = render_component(&mut viewer, 100, 24);
+        // Should not show Project: line when extraction fails
+        assert!(!buffer_contains(&buffer, "Project:"));
     }
 
     #[test]
@@ -378,7 +430,7 @@ mod tests {
 
         // Test session ID copy
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(id)) if id == "session-123"));
+        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123"));
 
         // Simulate the message being set after copy
         viewer.set_message(Some("✓ Copied session ID".to_string()));
@@ -388,7 +440,7 @@ mod tests {
         // Test file path copy
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::empty()));
         assert!(
-            matches!(msg, Some(Message::CopyToClipboard(path)) if path == "/path/to/file.jsonl")
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::FilePath(path))) if path == "/path/to/file.jsonl")
         );
 
         // Simulate the message being set after copy

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -256,19 +256,29 @@ mod tests {
 
         // Test copy single message
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::JsonData(_)))));
+        assert!(matches!(
+            msg,
+            Some(Message::CopyToClipboard(CopyContent::JsonData(_)))
+        ));
 
         // Test copy all messages
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('C'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::JsonData(_)))));
+        assert!(matches!(
+            msg,
+            Some(Message::CopyToClipboard(CopyContent::JsonData(_)))
+        ));
 
         // Test copy session ID
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123"));
+        assert!(
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123")
+        );
 
         // Test copy session ID with uppercase
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('I'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123"));
+        assert!(
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123")
+        );
 
         // Test copy file path
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::empty()));
@@ -289,7 +299,9 @@ mod tests {
         viewer.set_messages(vec![
             r#"{"type":"user","message":{"content":"test"}}"#.to_string(),
         ]);
-        viewer.set_file_path(Some("/Users/masatomokusaka/.claude/projects/-Users-project-name/session.jsonl".to_string()));
+        viewer.set_file_path(Some(
+            "/Users/masatomokusaka/.claude/projects/-Users-project-name/session.jsonl".to_string(),
+        ));
 
         // Test copy project path
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('p'), KeyModifiers::empty()));
@@ -316,18 +328,23 @@ mod tests {
     #[test]
     fn test_extract_project_path() {
         let mut viewer = SessionViewer::new();
-        
+
         // Test with typical Claude project path
         viewer.set_file_path(Some("/Users/masatomokusaka/.claude/projects/-Users-masatomokusaka-src-github-com-clerk-clerk-playwright-nextjs/fb101a01-0e24-4a45-9e42-74117ebc20e6.jsonl".to_string()));
-        
+
         let buffer = render_component(&mut viewer, 180, 24);
-        assert!(buffer_contains(&buffer, "Project: /Users/masatomokusaka/src/github/com/clerk/clerk/playwright/nextjs"));
-        
+        assert!(buffer_contains(
+            &buffer,
+            "Project: /Users/masatomokusaka/src/github/com/clerk/clerk/playwright/nextjs"
+        ));
+
         // Test with shorter path
-        viewer.set_file_path(Some("/home/user/.claude/projects/-tmp-test/session.jsonl".to_string()));
+        viewer.set_file_path(Some(
+            "/home/user/.claude/projects/-tmp-test/session.jsonl".to_string(),
+        ));
         let buffer = render_component(&mut viewer, 100, 24);
         assert!(buffer_contains(&buffer, "Project: /tmp/test"));
-        
+
         // Test with no project path (invalid format)
         viewer.set_file_path(Some("/invalid/path/file.jsonl".to_string()));
         let buffer = render_component(&mut viewer, 100, 24);
@@ -430,7 +447,9 @@ mod tests {
 
         // Test session ID copy
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123"));
+        assert!(
+            matches!(msg, Some(Message::CopyToClipboard(CopyContent::SessionId(id))) if id == "session-123")
+        );
 
         // Simulate the message being set after copy
         viewer.set_message(Some("✓ Copied session ID".to_string()));

--- a/src/interactive_ratatui/ui/events.rs
+++ b/src/interactive_ratatui/ui/events.rs
@@ -1,6 +1,16 @@
 use crate::query::condition::SearchResult;
 
 #[derive(Clone, Debug)]
+pub enum CopyContent {
+    FilePath(String),
+    ProjectPath(String),
+    SessionId(String),
+    MessageContent(String),
+    JsonData(String),
+    FullResultDetails(String),
+}
+
+#[derive(Clone, Debug)]
 pub enum Message {
     // Search events
     QueryChanged(String),
@@ -40,7 +50,7 @@ pub enum Message {
     ToggleTruncation,
 
     // Clipboard
-    CopyToClipboard(String),
+    CopyToClipboard(CopyContent),
 
     // Async events
     SearchStarted(u64),


### PR DESCRIPTION
## Summary
This PR refactors the copy-to-clipboard functionality to use an enum-based approach for tracking what type of content is being copied, replacing the previous string-based guessing approach.

## Changes
- Added `CopyContent` enum with variants for different content types:
  - `FilePath(String)` - for file paths
  - `ProjectPath(String)` - for project paths
  - `SessionId(String)` - for session IDs
  - `MessageContent(String)` - for message text
  - `JsonData(String)` - for JSON data
  - `FullResultDetails(String)` - for complete result details

- Updated `CopyToClipboard` message to use the enum instead of raw strings
- Fixed feedback messages to show appropriate text based on content type:
  - "✓ Copied project path" for project paths
  - "✓ Copied file path" for file paths
  - "✓ Copied session ID" for session IDs
  - etc.

- Updated all components that perform copy operations:
  - `session_viewer.rs` - for project path, file path, and session ID copying
  - `result_detail.rs` - for all copy shortcuts (f/F, i/I, p/P, m/M, r/R, c/C)

- Updated all tests to work with the new enum

## Test Plan
- [x] All unit tests pass
- [x] All integration tests pass
- [x] No clippy warnings
- [x] Manual testing of copy operations in interactive mode
- [x] Verified correct feedback messages for each copy type

## Screenshots
Before: "Copied file path" shown when copying project path
After: "Copied project path" shown when copying project path

## Related Issues
Fixes incorrect feedback message when copying project path with 'p' shortcut.