### PR TITLE
Fix empty message body in Result Detail view for tool results

### DIFF
--- a/src/schemas/session_message.rs
+++ b/src/schemas/session_message.rs
@@ -207,6 +207,12 @@ impl SessionMessage {
                                             texts.push(item.text.clone());
                                         }
                                     }
+                                    ToolResultContent::Value(val) => {
+                                        // Try to extract string from Value
+                                        if let Some(s) = val.as_str() {
+                                            texts.push(s.to_string());
+                                        }
+                                    }
                                     _ => {}
                                 },
                                 Content::ToolResult { content: None, .. } => {}


### PR DESCRIPTION
## Problem
Messages containing tool results were showing empty content in the Result Detail view. This was particularly noticeable for user messages that included tool result content, such as file contents.

## Root Cause
The issue was in the `get_content_text()` method in `src/schemas/session_message.rs`. When tool result content was stored as a plain string in JSON, it was being parsed as `ToolResultContent::Value` instead of `ToolResultContent::String`. The existing code only handled `String` and `TextArray` variants, missing the `Value` variant.

## Solution
Added handling for the `ToolResultContent::Value` variant in the `get_content_text()` method:

```rust
ToolResultContent::Value(val) => {
    // Try to extract string from Value
    if let Some(s) = val.as_str() {
        texts.push(s.to_string());
    }
}
```

## Testing
- Verified that tool result messages now display their content properly in the Result Detail view
- Confirmed that file content in tool results is now visible instead of showing empty message bodies

## Impact
This fix resolves the issue where certain user messages (particularly those containing tool results with file content) would appear empty in the interactive UI's Result Detail view.