### PR TITLE
fix: resolve SessionNavigated message compilation errors

### DIFF
--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -435,11 +435,17 @@ impl Component for SessionViewer {
                 }
                 KeyCode::Char('u') if key.modifiers == KeyModifiers::CONTROL => {
                     self.list_viewer.half_page_up();
-                    Some(Message::SessionNavigated)
+                    Some(Message::SessionNavigated(
+                        self.list_viewer.selected_index,
+                        self.list_viewer.scroll_offset,
+                    ))
                 }
                 KeyCode::Char('d') if key.modifiers == KeyModifiers::CONTROL => {
                     self.list_viewer.half_page_down();
-                    Some(Message::SessionNavigated)
+                    Some(Message::SessionNavigated(
+                        self.list_viewer.selected_index,
+                        self.list_viewer.scroll_offset,
+                    ))
                 }
                 KeyCode::Tab if !key.modifiers.contains(KeyModifiers::CONTROL) => {
                     Some(Message::ToggleSessionRoleFilter)

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -1116,7 +1116,7 @@ mod tests {
             KeyCode::Char('d'),
             KeyModifiers::CONTROL,
         ));
-        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        assert!(matches!(msg, Some(Message::SessionNavigated(_, _))));
         // The exact position depends on viewport height, but should have moved down
         let first_pos = viewer.list_viewer.selected_index;
         assert!(first_pos > 0);
@@ -1126,7 +1126,7 @@ mod tests {
             KeyCode::Char('d'),
             KeyModifiers::CONTROL,
         ));
-        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        assert!(matches!(msg, Some(Message::SessionNavigated(_, _))));
         let second_pos = viewer.list_viewer.selected_index;
         assert!(second_pos > first_pos);
 
@@ -1138,7 +1138,7 @@ mod tests {
             KeyCode::Char('d'),
             KeyModifiers::CONTROL,
         ));
-        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        assert!(matches!(msg, Some(Message::SessionNavigated(_, _))));
         assert_eq!(viewer.list_viewer.selected_index, 29);
 
         // Can't move down from last item
@@ -1146,7 +1146,7 @@ mod tests {
             KeyCode::Char('d'),
             KeyModifiers::CONTROL,
         ));
-        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        assert!(matches!(msg, Some(Message::SessionNavigated(_, _))));
         assert_eq!(viewer.list_viewer.selected_index, 29);
 
         // Ctrl+U to move up half page
@@ -1154,7 +1154,7 @@ mod tests {
             KeyCode::Char('u'),
             KeyModifiers::CONTROL,
         ));
-        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        assert!(matches!(msg, Some(Message::SessionNavigated(_, _))));
         assert!(viewer.list_viewer.selected_index < 29);
 
         // Move to position 5
@@ -1165,7 +1165,7 @@ mod tests {
             KeyCode::Char('u'),
             KeyModifiers::CONTROL,
         ));
-        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        assert!(matches!(msg, Some(Message::SessionNavigated(_, _))));
         assert_eq!(viewer.list_viewer.selected_index, 0);
 
         // Can't move up from first item
@@ -1173,7 +1173,7 @@ mod tests {
             KeyCode::Char('u'),
             KeyModifiers::CONTROL,
         ));
-        assert!(matches!(msg, Some(Message::SessionNavigated)));
+        assert!(matches!(msg, Some(Message::SessionNavigated(_, _))));
         assert_eq!(viewer.list_viewer.selected_index, 0);
     }
 


### PR DESCRIPTION
## Summary
- Fixed compilation errors where SessionNavigated message was called without required arguments
- Updated test assertions to match the tuple variant pattern

## Changes
- Added missing (usize, usize) arguments to SessionNavigated message calls in session_viewer.rs
- Fixed test assertions to use SessionNavigated(_, _) pattern matching

## Test plan
- [x] All tests pass locally with `cargo test`
- [x] No clippy warnings with `cargo clippy -- -D warnings`
- [x] Code is properly formatted with `cargo fmt`
- [x] CI passes on all platforms