### PR TITLE
Remove duplicate truncation toggle text from search results

### DIFF
--- a/src/interactive_ratatui/ui/components/result_list.rs
+++ b/src/interactive_ratatui/ui/components/result_list.rs
@@ -75,7 +75,7 @@ impl Component for ResultList {
         let title_lines = vec![
             Line::from(vec![Span::styled("Search Results", Styles::title())]),
             Line::from(vec![Span::raw(format!(
-                "{} results found | Ctrl+T: Toggle truncation",
+                "{} results found",
                 self.list_viewer.filtered_count()
             ))]),
         ];


### PR DESCRIPTION
## Summary
- Removed redundant "Ctrl+T: Toggle truncation" text from the search results header
- The keyboard shortcut remains visible in the bottom status bar along with other shortcuts

## Test plan
- [x] Build the project with `cargo build`
- [x] Run interactive mode and verify the header shows only the result count
- [x] Confirm the truncation toggle shortcut is still visible in the bottom status bar
- [x] Verify that Ctrl+T functionality still works as expected