### PR TITLE
Fix search results order toggling to fetch correct messages

### DIFF
--- a/src/interactive_ratatui/application/search_service.rs
+++ b/src/interactive_ratatui/application/search_service.rs
@@ -16,7 +16,7 @@ impl SearchService {
     }
 
     pub fn search(&self, request: SearchRequest) -> Result<SearchResponse> {
-        let results = self.execute_search(&request.query, &request.pattern, request.role_filter)?;
+        let results = self.execute_search(&request.query, &request.pattern, request.role_filter, request.order)?;
 
         Ok(SearchResponse {
             id: request.id,
@@ -29,6 +29,7 @@ impl SearchService {
         query: &str,
         pattern: &str,
         role_filter: Option<String>,
+        order: crate::interactive_ratatui::domain::models::SearchOrder,
     ) -> Result<Vec<SearchResult>> {
         let query_condition = if query.trim().is_empty() {
             // Empty query means "match all" - use empty AND condition
@@ -39,9 +40,9 @@ impl SearchService {
 
         let (results, _, _) =
             self.engine
-                .search_with_role_filter(pattern, query_condition, role_filter)?;
+                .search_with_role_filter_and_order(pattern, query_condition, role_filter, order)?;
 
-        // No sorting here - AppState will handle sorting based on current order
+        // Results are already sorted by the engine based on the order
         Ok(results)
     }
 }

--- a/src/interactive_ratatui/application/search_service.rs
+++ b/src/interactive_ratatui/application/search_service.rs
@@ -16,7 +16,12 @@ impl SearchService {
     }
 
     pub fn search(&self, request: SearchRequest) -> Result<SearchResponse> {
-        let results = self.execute_search(&request.query, &request.pattern, request.role_filter, request.order)?;
+        let results = self.execute_search(
+            &request.query,
+            &request.pattern,
+            request.role_filter,
+            request.order,
+        )?;
 
         Ok(SearchResponse {
             id: request.id,
@@ -38,9 +43,12 @@ impl SearchService {
             parse_query(query)?
         };
 
-        let (results, _, _) =
-            self.engine
-                .search_with_role_filter_and_order(pattern, query_condition, role_filter, order)?;
+        let (results, _, _) = self.engine.search_with_role_filter_and_order(
+            pattern,
+            query_condition,
+            role_filter,
+            order,
+        )?;
 
         // Results are already sorted by the engine based on the order
         Ok(results)

--- a/src/interactive_ratatui/application/search_service.rs
+++ b/src/interactive_ratatui/application/search_service.rs
@@ -37,13 +37,11 @@ impl SearchService {
             parse_query(query)?
         };
 
-        let (mut results, _, _) =
+        let (results, _, _) =
             self.engine
                 .search_with_role_filter(pattern, query_condition, role_filter)?;
 
-        // Sort by timestamp descending
-        results.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
-
+        // No sorting here - AppState will handle sorting based on current order
         Ok(results)
     }
 }

--- a/src/interactive_ratatui/application/search_service_test.rs
+++ b/src/interactive_ratatui/application/search_service_test.rs
@@ -2,7 +2,7 @@
 mod tests {
     use super::super::search_service::*;
     use crate::SearchOptions;
-    use crate::interactive_ratatui::domain::models::{SearchRequest, SearchOrder};
+    use crate::interactive_ratatui::domain::models::{SearchOrder, SearchRequest};
 
     #[test]
     fn test_search_service_creation() {

--- a/src/interactive_ratatui/application/search_service_test.rs
+++ b/src/interactive_ratatui/application/search_service_test.rs
@@ -2,7 +2,7 @@
 mod tests {
     use super::super::search_service::*;
     use crate::SearchOptions;
-    use crate::interactive_ratatui::domain::models::SearchRequest;
+    use crate::interactive_ratatui::domain::models::{SearchRequest, SearchOrder};
 
     #[test]
     fn test_search_service_creation() {
@@ -28,6 +28,7 @@ mod tests {
             query: "   ".to_string(), // Empty/whitespace query
             role_filter: None,
             pattern: "/nonexistent/test/path/*.jsonl".to_string(),
+            order: SearchOrder::Descending,
         };
 
         let response = service.search(request).unwrap();
@@ -52,6 +53,7 @@ mod tests {
             query: "test".to_string(),
             role_filter: Some("user".to_string()),
             pattern: "/nonexistent/test/path/*.jsonl".to_string(),
+            order: SearchOrder::Descending,
         };
 
         // This would normally search files, but without test files it returns empty
@@ -77,6 +79,7 @@ mod tests {
                 query: "test".to_string(),
                 role_filter: None,
                 pattern: "/nonexistent/test/path/*.jsonl".to_string(),
+                order: SearchOrder::Descending,
             };
 
             let response = service.search(request).unwrap();
@@ -97,6 +100,7 @@ mod tests {
             query: "[[invalid regex".to_string(),
             role_filter: None,
             pattern: "/nonexistent/test/path/*.jsonl".to_string(),
+            order: SearchOrder::Descending,
         };
 
         // Should handle invalid regex gracefully
@@ -123,6 +127,7 @@ mod tests {
             query: "".to_string(),
             role_filter: None,
             pattern: "/nonexistent/test/path/*.jsonl".to_string(),
+            order: SearchOrder::Descending,
         };
 
         // Request with role filter should get only that role
@@ -131,6 +136,7 @@ mod tests {
             query: "".to_string(),
             role_filter: Some("user".to_string()),
             pattern: "/nonexistent/test/path/*.jsonl".to_string(),
+            order: SearchOrder::Descending,
         };
 
         // Both will return empty due to missing file, but the structure is correct

--- a/src/interactive_ratatui/domain/models.rs
+++ b/src/interactive_ratatui/domain/models.rs
@@ -16,6 +16,12 @@ pub enum SessionOrder {
     Descending,
 }
 
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum SearchOrder {
+    Descending, // Default - newest first
+    Ascending,  // Reverse - oldest first
+}
+
 pub struct CachedFile {
     pub messages: Vec<SessionMessage>,
     pub raw_lines: Vec<String>,

--- a/src/interactive_ratatui/domain/models.rs
+++ b/src/interactive_ratatui/domain/models.rs
@@ -35,6 +35,7 @@ pub struct SearchRequest {
     pub query: String,
     pub role_filter: Option<String>,
     pub pattern: String,
+    pub order: SearchOrder,
 }
 
 pub struct SearchResponse {

--- a/src/interactive_ratatui/domain/models_test.rs
+++ b/src/interactive_ratatui/domain/models_test.rs
@@ -43,6 +43,7 @@ mod tests {
             query: "test query".to_string(),
             role_filter: Some("user".to_string()),
             pattern: "*.jsonl".to_string(),
+            order: SearchOrder::Descending,
         };
 
         assert_eq!(request.id, 42);
@@ -102,6 +103,7 @@ mod tests {
             query: "test".to_string(),
             role_filter: None,
             pattern: "*.jsonl".to_string(),
+            order: SearchOrder::Ascending,
         };
 
         let cloned = original.clone();
@@ -109,5 +111,6 @@ mod tests {
         assert_eq!(cloned.query, original.query);
         assert_eq!(cloned.role_filter, original.role_filter);
         assert_eq!(cloned.pattern, original.pattern);
+        assert_eq!(cloned.order, original.order);
     }
 }

--- a/src/interactive_ratatui/integration_tests.rs
+++ b/src/interactive_ratatui/integration_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use super::super::*;
-    use crate::interactive_ratatui::domain::models::{Mode, SessionOrder, SearchOrder};
+    use crate::interactive_ratatui::domain::models::{Mode, SearchOrder, SessionOrder};
     use crate::interactive_ratatui::ui::events::{CopyContent, Message};
     use crate::interactive_ratatui::ui::navigation::{
         NavigationHistory, NavigationState, SearchStateSnapshot, SessionStateSnapshot,

--- a/src/interactive_ratatui/integration_tests.rs
+++ b/src/interactive_ratatui/integration_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use super::super::*;
-    use crate::interactive_ratatui::domain::models::{Mode, SessionOrder};
+    use crate::interactive_ratatui::domain::models::{Mode, SessionOrder, SearchOrder};
     use crate::interactive_ratatui::ui::events::{CopyContent, Message};
     use crate::interactive_ratatui::ui::navigation::{
         NavigationHistory, NavigationState, SearchStateSnapshot, SessionStateSnapshot,
@@ -420,6 +420,7 @@ mod tests {
                 selected_index: 0,
                 scroll_offset: 0,
                 role_filter: None,
+                order: SearchOrder::Descending,
             },
             session_state: SessionStateSnapshot {
                 messages: Vec::new(),
@@ -455,6 +456,7 @@ mod tests {
                 selected_index: 0,
                 scroll_offset: 0,
                 role_filter: None,
+                order: SearchOrder::Descending,
             },
             session_state: SessionStateSnapshot {
                 messages: Vec::new(),

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -230,6 +230,10 @@ impl InteractiveSearch {
             KeyCode::Char('s') if key.modifiers == KeyModifiers::CONTROL => {
                 self.renderer.get_result_list_mut().handle_key(key)
             }
+            // Handle Ctrl+O for toggling search order
+            KeyCode::Char('o') if key.modifiers == KeyModifiers::CONTROL => {
+                Some(Message::ToggleSearchOrder)
+            }
             KeyCode::Up
             | KeyCode::Down
             | KeyCode::PageUp

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -15,7 +15,7 @@ use crate::SearchOptions;
 
 mod application;
 mod constants;
-mod domain;
+pub mod domain;
 pub mod ui;
 
 #[cfg(test)]
@@ -339,6 +339,7 @@ impl InteractiveSearch {
                 query: self.state.search.query.clone(),
                 role_filter: self.state.search.role_filter.clone(),
                 pattern: self.pattern.clone(),
+                order: self.state.search.order,
             };
             let _ = sender.send(request);
         }

--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -1,5 +1,5 @@
 use crate::interactive_ratatui::constants::*;
-use crate::interactive_ratatui::domain::models::{SessionOrder, SearchOrder};
+use crate::interactive_ratatui::domain::models::{SearchOrder, SessionOrder};
 use crate::interactive_ratatui::ui::commands::Command;
 use crate::interactive_ratatui::ui::events::Message;
 use crate::interactive_ratatui::ui::navigation::{
@@ -618,5 +618,4 @@ impl AppState {
         self.mode = mode;
         self.initialize_mode()
     }
-
 }

--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -105,8 +105,7 @@ impl AppState {
             Message::SearchCompleted(results) => {
                 self.search.results = results;
                 self.search.is_searching = false;
-                // Sort results based on current order
-                self.sort_search_results();
+                // Results are already sorted by the search engine based on current order
                 self.ui.message = None;
                 Command::None
             }
@@ -247,9 +246,8 @@ impl AppState {
                     SearchOrder::Descending => SearchOrder::Ascending,
                     SearchOrder::Ascending => SearchOrder::Descending,
                 };
-                // Re-sort the current results without re-executing search
-                self.sort_search_results();
-                Command::None
+                // Re-execute the search with the new order to get different results
+                Command::ExecuteSearch
             }
             Message::ToggleTruncation => {
                 self.ui.truncation_enabled = !self.ui.truncation_enabled;
@@ -621,21 +619,4 @@ impl AppState {
         self.initialize_mode()
     }
 
-    // Sort search results based on current order
-    pub fn sort_search_results(&mut self) {
-        match self.search.order {
-            SearchOrder::Descending => {
-                // Sort by timestamp descending (newest first)
-                self.search.results.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
-            }
-            SearchOrder::Ascending => {
-                // Sort by timestamp ascending (oldest first)
-                self.search.results.sort_by(|a, b| a.timestamp.cmp(&b.timestamp));
-            }
-        }
-        
-        // Reset selection to first item
-        self.search.selected_index = 0;
-        self.search.scroll_offset = 0;
-    }
 }

--- a/src/interactive_ratatui/ui/app_state_test.rs
+++ b/src/interactive_ratatui/ui/app_state_test.rs
@@ -3,7 +3,7 @@ mod tests {
     use super::super::app_state::*;
     use super::super::commands::Command;
     use super::super::events::{CopyContent, Message};
-    use crate::interactive_ratatui::domain::models::{Mode, SessionOrder, SearchOrder};
+    use crate::interactive_ratatui::domain::models::{Mode, SearchOrder, SessionOrder};
     use crate::query::condition::{QueryCondition, SearchResult};
 
     fn create_test_state() -> AppState {
@@ -269,15 +269,15 @@ mod tests {
     #[test]
     fn test_toggle_search_order() {
         let mut state = create_test_state();
-        
+
         // Default should be Descending (newest first)
         assert_eq!(state.search.order, SearchOrder::Descending);
-        
+
         // Toggle to Ascending (oldest first)
         let command = state.update(Message::ToggleSearchOrder);
         assert_eq!(command, Command::ExecuteSearch); // Should trigger new search
         assert_eq!(state.search.order, SearchOrder::Ascending);
-        
+
         // Toggle back to Descending
         let command = state.update(Message::ToggleSearchOrder);
         assert_eq!(command, Command::ExecuteSearch); // Should trigger new search
@@ -287,21 +287,21 @@ mod tests {
     #[test]
     fn test_search_completed_respects_engine_order() {
         let mut state = create_test_state();
-        
+
         // Create test results already sorted by the engine
         let mut result1 = create_test_result();
         result1.timestamp = "2024-01-01T12:00:00Z".to_string();
-        
+
         let mut result2 = create_test_result();
         result2.timestamp = "2024-01-02T12:00:00Z".to_string();
-        
+
         let mut result3 = create_test_result();
         result3.timestamp = "2024-01-03T12:00:00Z".to_string();
-        
+
         // Results come pre-sorted from the engine
         let results = vec![result3.clone(), result2.clone(), result1.clone()]; // Descending order
         state.update(Message::SearchCompleted(results));
-        
+
         // Should maintain the order from the engine
         assert_eq!(state.search.results[0].timestamp, "2024-01-03T12:00:00Z");
         assert_eq!(state.search.results[1].timestamp, "2024-01-02T12:00:00Z");

--- a/src/interactive_ratatui/ui/app_state_test.rs
+++ b/src/interactive_ratatui/ui/app_state_test.rs
@@ -270,47 +270,25 @@ mod tests {
     fn test_toggle_search_order() {
         let mut state = create_test_state();
         
-        // Create test results with different timestamps
-        let mut result1 = create_test_result();
-        result1.timestamp = "2024-01-01T12:00:00Z".to_string();
-        
-        let mut result2 = create_test_result();
-        result2.timestamp = "2024-01-02T12:00:00Z".to_string();
-        
-        let mut result3 = create_test_result();
-        result3.timestamp = "2024-01-03T12:00:00Z".to_string();
-        
-        state.search.results = vec![result1, result2, result3];
-        
         // Default should be Descending (newest first)
         assert_eq!(state.search.order, SearchOrder::Descending);
-        state.sort_search_results();
-        assert_eq!(state.search.results[0].timestamp, "2024-01-03T12:00:00Z");
-        assert_eq!(state.search.results[1].timestamp, "2024-01-02T12:00:00Z");
-        assert_eq!(state.search.results[2].timestamp, "2024-01-01T12:00:00Z");
         
         // Toggle to Ascending (oldest first)
         let command = state.update(Message::ToggleSearchOrder);
-        assert_eq!(command, Command::None);
+        assert_eq!(command, Command::ExecuteSearch); // Should trigger new search
         assert_eq!(state.search.order, SearchOrder::Ascending);
-        assert_eq!(state.search.results[0].timestamp, "2024-01-01T12:00:00Z");
-        assert_eq!(state.search.results[1].timestamp, "2024-01-02T12:00:00Z");
-        assert_eq!(state.search.results[2].timestamp, "2024-01-03T12:00:00Z");
         
         // Toggle back to Descending
         let command = state.update(Message::ToggleSearchOrder);
-        assert_eq!(command, Command::None);
+        assert_eq!(command, Command::ExecuteSearch); // Should trigger new search
         assert_eq!(state.search.order, SearchOrder::Descending);
-        assert_eq!(state.search.results[0].timestamp, "2024-01-03T12:00:00Z");
-        assert_eq!(state.search.results[1].timestamp, "2024-01-02T12:00:00Z");
-        assert_eq!(state.search.results[2].timestamp, "2024-01-01T12:00:00Z");
     }
 
     #[test]
-    fn test_search_completed_sorts_by_order() {
+    fn test_search_completed_respects_engine_order() {
         let mut state = create_test_state();
         
-        // Create test results with different timestamps
+        // Create test results already sorted by the engine
         let mut result1 = create_test_result();
         result1.timestamp = "2024-01-01T12:00:00Z".to_string();
         
@@ -320,15 +298,13 @@ mod tests {
         let mut result3 = create_test_result();
         result3.timestamp = "2024-01-03T12:00:00Z".to_string();
         
-        // Set order to Ascending before search completion
-        state.search.order = SearchOrder::Ascending;
-        
-        let results = vec![result2, result1, result3]; // Unsorted
+        // Results come pre-sorted from the engine
+        let results = vec![result3.clone(), result2.clone(), result1.clone()]; // Descending order
         state.update(Message::SearchCompleted(results));
         
-        // Should be sorted by ascending order
-        assert_eq!(state.search.results[0].timestamp, "2024-01-01T12:00:00Z");
+        // Should maintain the order from the engine
+        assert_eq!(state.search.results[0].timestamp, "2024-01-03T12:00:00Z");
         assert_eq!(state.search.results[1].timestamp, "2024-01-02T12:00:00Z");
-        assert_eq!(state.search.results[2].timestamp, "2024-01-03T12:00:00Z");
+        assert_eq!(state.search.results[2].timestamp, "2024-01-01T12:00:00Z");
     }
 }

--- a/src/interactive_ratatui/ui/commands.rs
+++ b/src/interactive_ratatui/ui/commands.rs
@@ -1,6 +1,6 @@
 use super::events::CopyContent;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum Command {
     None,
     ExecuteSearch,

--- a/src/interactive_ratatui/ui/components/help_dialog.rs
+++ b/src/interactive_ratatui/ui/components/help_dialog.rs
@@ -49,6 +49,7 @@ impl HelpDialog {
             Line::from("  Enter       - View result details"),
             Line::from("  Ctrl+S      - Jump directly to session viewer"),
             Line::from("  Tab         - Toggle role filter (user/assistant/system)"),
+            Line::from("  Ctrl+O      - Toggle sort order (newest/oldest first)"),
             Line::from("  Esc         - Quit"),
             Line::from(""),
             Line::from(vec![Span::styled(
@@ -95,7 +96,7 @@ impl HelpDialog {
             Line::from("  /           - Search within session"),
             Line::from("  c           - Copy selected message to clipboard"),
             Line::from("  C           - Copy all filtered messages to clipboard"),
-            Line::from("  o           - Toggle sort order (ascending/descending/original)"),
+            Line::from("  Ctrl+O      - Toggle sort order (ascending/descending)"),
             Line::from("  Backspace   - Back to search results (or clear search)"),
             Line::from("  Esc         - Back to search results"),
             Line::from(""),

--- a/src/interactive_ratatui/ui/components/search_bar.rs
+++ b/src/interactive_ratatui/ui/components/search_bar.rs
@@ -1,3 +1,4 @@
+use crate::interactive_ratatui::domain::models::SearchOrder;
 use crate::interactive_ratatui::ui::components::{Component, text_input::TextInput};
 use crate::interactive_ratatui::ui::events::Message;
 use crossterm::event::KeyEvent;
@@ -9,12 +10,18 @@ use ratatui::{
     widgets::{Block, Borders, Paragraph},
 };
 
-#[derive(Default)]
 pub struct SearchBar {
     text_input: TextInput,
     is_searching: bool,
     message: Option<String>,
     role_filter: Option<String>,
+    search_order: SearchOrder,
+}
+
+impl Default for SearchBar {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl SearchBar {
@@ -24,6 +31,7 @@ impl SearchBar {
             is_searching: false,
             message: None,
             role_filter: None,
+            search_order: SearchOrder::Descending,
         }
     }
 
@@ -43,6 +51,10 @@ impl SearchBar {
         self.role_filter = role_filter;
     }
 
+    pub fn set_search_order(&mut self, order: SearchOrder) {
+        self.search_order = order;
+    }
+
     pub fn get_query(&self) -> &str {
         self.text_input.text()
     }
@@ -60,6 +72,14 @@ impl Component for SearchBar {
         if let Some(role) = &self.role_filter {
             title.push_str(&format!(" [role:{role}]"));
         }
+        
+        // Add order info
+        let order_text = match self.search_order {
+            SearchOrder::Descending => "Desc",
+            SearchOrder::Ascending => "Asc",
+        };
+        title.push_str(&format!(" [order:{order_text}]"));
+        
         if let Some(msg) = &self.message {
             title.push_str(&format!(" - {msg}"));
         }

--- a/src/interactive_ratatui/ui/components/search_bar.rs
+++ b/src/interactive_ratatui/ui/components/search_bar.rs
@@ -72,14 +72,14 @@ impl Component for SearchBar {
         if let Some(role) = &self.role_filter {
             title.push_str(&format!(" [role:{role}]"));
         }
-        
+
         // Add order info
         let order_text = match self.search_order {
             SearchOrder::Descending => "Desc",
             SearchOrder::Ascending => "Asc",
         };
         title.push_str(&format!(" [order:{order_text}]"));
-        
+
         if let Some(msg) = &self.message {
             title.push_str(&format!(" - {msg}"));
         }

--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -257,7 +257,7 @@ impl Component for SessionViewer {
         let subtitle = subtitle_parts.join("\n");
 
         // Calculate status bar height based on terminal width
-        let status_text = "↑/↓ or Ctrl+P/N or Ctrl+U/D: Navigate | Tab: Role Filter | Enter: View Detail | o/Ctrl+O: Sort | c: Copy JSON | i: Copy Session ID | p: Copy Project Path | f: Copy File Path | /: Search | Alt+←/→: History | Esc: Back";
+        let status_text = "↑/↓ or Ctrl+P/N or Ctrl+U/D: Navigate | Tab: Role Filter | Enter: View Detail | Ctrl+O: Sort | c: Copy JSON | i: Copy Session ID | p: Copy Project Path | f: Copy File Path | /: Search | Alt+←/→: History | Esc: Back";
         let status_bar_height = {
             let text_len = status_text.len();
             let width = area.width as usize;
@@ -469,9 +469,6 @@ impl Component for SessionViewer {
                 KeyCode::Char('/') => {
                     self.is_searching = true;
                     None
-                }
-                KeyCode::Char('o') if !key.modifiers.contains(KeyModifiers::CONTROL) => {
-                    Some(Message::ToggleSessionOrder)
                 }
                 KeyCode::Char('o') if key.modifiers == KeyModifiers::CONTROL => {
                     Some(Message::ToggleSessionOrder)

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -374,14 +374,16 @@ mod tests {
     fn test_toggle_order() {
         let mut viewer = SessionViewer::new();
 
+        // Plain 'o' without Ctrl should not toggle order anymore
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::empty()));
-        assert!(matches!(msg, Some(Message::ToggleSessionOrder)));
+        assert!(msg.is_none());
     }
 
     #[test]
     fn test_toggle_order_with_ctrl() {
         let mut viewer = SessionViewer::new();
 
+        // Ctrl+O should toggle order
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::CONTROL));
         assert!(matches!(msg, Some(Message::ToggleSessionOrder)));
     }
@@ -1354,5 +1356,40 @@ mod tests {
         assert!(buffer_contains(&buffer, "✓ Test message"));
         assert!(buffer_contains(&buffer, "Navigate"));
         assert!(buffer_contains(&buffer, "Back"));
+    }
+
+    #[test]
+    fn test_ctrl_o_toggle_order_normal_mode() {
+        let mut viewer = SessionViewer::new();
+        
+        // Initial order should be Ascending
+        viewer.set_order(SessionOrder::Ascending);
+        
+        // Ctrl+O should toggle order
+        let msg = viewer.handle_key(create_key_event_with_modifiers(
+            KeyCode::Char('o'),
+            KeyModifiers::CONTROL,
+        ));
+        assert!(matches!(msg, Some(Message::ToggleSessionOrder)));
+        
+        // Plain 'o' without Ctrl should not toggle order anymore
+        let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::empty()));
+        assert!(msg.is_none());
+    }
+
+    #[test]
+    fn test_ctrl_o_toggle_order_search_mode() {
+        let mut viewer = SessionViewer::new();
+        
+        // Enter search mode
+        viewer.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::empty()));
+        viewer.start_search();
+        
+        // Ctrl+O should toggle order even in search mode
+        let msg = viewer.handle_key(create_key_event_with_modifiers(
+            KeyCode::Char('o'),
+            KeyModifiers::CONTROL,
+        ));
+        assert!(matches!(msg, Some(Message::ToggleSessionOrder)));
     }
 }

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -1361,17 +1361,17 @@ mod tests {
     #[test]
     fn test_ctrl_o_toggle_order_normal_mode() {
         let mut viewer = SessionViewer::new();
-        
+
         // Initial order should be Ascending
         viewer.set_order(SessionOrder::Ascending);
-        
+
         // Ctrl+O should toggle order
         let msg = viewer.handle_key(create_key_event_with_modifiers(
             KeyCode::Char('o'),
             KeyModifiers::CONTROL,
         ));
         assert!(matches!(msg, Some(Message::ToggleSessionOrder)));
-        
+
         // Plain 'o' without Ctrl should not toggle order anymore
         let msg = viewer.handle_key(KeyEvent::new(KeyCode::Char('o'), KeyModifiers::empty()));
         assert!(msg.is_none());
@@ -1380,11 +1380,11 @@ mod tests {
     #[test]
     fn test_ctrl_o_toggle_order_search_mode() {
         let mut viewer = SessionViewer::new();
-        
+
         // Enter search mode
         viewer.handle_key(KeyEvent::new(KeyCode::Char('/'), KeyModifiers::empty()));
         viewer.start_search();
-        
+
         // Ctrl+O should toggle order even in search mode
         let msg = viewer.handle_key(create_key_event_with_modifiers(
             KeyCode::Char('o'),

--- a/src/interactive_ratatui/ui/events.rs
+++ b/src/interactive_ratatui/ui/events.rs
@@ -1,6 +1,6 @@
 use crate::query::condition::SearchResult;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum CopyContent {
     FilePath(String),
     ProjectPath(String),
@@ -19,6 +19,7 @@ pub enum Message {
     SelectResult(usize),
     ScrollUp,
     ScrollDown,
+    ToggleSearchOrder,
 
     // Mode changes
     EnterResultDetail,

--- a/src/interactive_ratatui/ui/navigation.rs
+++ b/src/interactive_ratatui/ui/navigation.rs
@@ -1,4 +1,4 @@
-use crate::interactive_ratatui::domain::models::{Mode, SessionOrder};
+use crate::interactive_ratatui::domain::models::{Mode, SessionOrder, SearchOrder};
 use crate::query::condition::SearchResult;
 
 /// Represents a complete navigation state that can be restored
@@ -18,6 +18,7 @@ pub struct SearchStateSnapshot {
     pub selected_index: usize,
     pub scroll_offset: usize,
     pub role_filter: Option<String>,
+    pub order: SearchOrder,
 }
 
 /// Snapshot of session state
@@ -190,6 +191,7 @@ mod tests {
                 selected_index: 0,
                 scroll_offset: 0,
                 role_filter: None,
+                order: SearchOrder::Descending,
             },
             session_state: SessionStateSnapshot {
                 messages: Vec::new(),

--- a/src/interactive_ratatui/ui/navigation.rs
+++ b/src/interactive_ratatui/ui/navigation.rs
@@ -1,4 +1,4 @@
-use crate::interactive_ratatui::domain::models::{Mode, SessionOrder, SearchOrder};
+use crate::interactive_ratatui::domain::models::{Mode, SearchOrder, SessionOrder};
 use crate::query::condition::SearchResult;
 
 /// Represents a complete navigation state that can be restored

--- a/src/interactive_ratatui/ui/renderer.rs
+++ b/src/interactive_ratatui/ui/renderer.rs
@@ -74,8 +74,7 @@ impl Renderer {
         }
         self.search_bar
             .set_role_filter(state.search.role_filter.clone());
-        self.search_bar
-            .set_search_order(state.search.order);
+        self.search_bar.set_search_order(state.search.order);
 
         // Update result list state
         self.result_list.set_results(state.search.results.clone());

--- a/src/interactive_ratatui/ui/renderer.rs
+++ b/src/interactive_ratatui/ui/renderer.rs
@@ -74,6 +74,8 @@ impl Renderer {
         }
         self.search_bar
             .set_role_filter(state.search.role_filter.clone());
+        self.search_bar
+            .set_search_order(state.search.order);
 
         // Update result list state
         self.result_list.set_results(state.search.results.clone());


### PR DESCRIPTION
## Summary

This PR fixes the issue where toggling search order (Ctrl+O) only reordered already-fetched results instead of fetching different messages based on the sort order.

## Problem

When users switched to Ascending order, they expected to see older messages but instead just saw the newest messages reordered. This was because:
1. The search engine sorted results AFTER truncating to maxResults
2. The UI only reordered existing results without re-executing the search

## Solution

- Modified search engine to accept sort order as a parameter
- Sort results BEFORE truncating to maxResults
- Changed ToggleSearchOrder to trigger a new search instead of just reordering
- Pass the current order through SearchRequest to the engine

## Changes

- Added `search_with_role_filter_and_order` method to SearchEngine
- Added `order` field to SearchRequest
- Updated SearchService to pass order to the engine
- Changed ToggleSearchOrder behavior from reordering to re-searching
- Removed the now-unnecessary `sort_search_results` method
- Updated all tests to work with the new structure

## Testing

- All existing tests pass
- Search results now correctly show older messages when in Ascending order
- Search results show newer messages when in Descending order
- Toggling order triggers a new search as expected