### PR TITLE
Fix unwrap() usage in production code to prevent panics

### DIFF
--- a/src/interactive_ratatui/application/cache_service.rs
+++ b/src/interactive_ratatui/application/cache_service.rs
@@ -58,8 +58,11 @@ impl CacheService {
             );
         }
 
-        self.files
-            .get(path)
-            .ok_or_else(|| anyhow::anyhow!("Failed to retrieve cached file from path: {}", path.display()))
+        self.files.get(path).ok_or_else(|| {
+            anyhow::anyhow!(
+                "Failed to retrieve cached file from path: {}",
+                path.display()
+            )
+        })
     }
 }

--- a/src/interactive_ratatui/application/cache_service.rs
+++ b/src/interactive_ratatui/application/cache_service.rs
@@ -58,6 +58,8 @@ impl CacheService {
             );
         }
 
-        Ok(self.files.get(path).unwrap())
+        self.files
+            .get(path)
+            .ok_or_else(|| anyhow::anyhow!("Failed to retrieve cached file from path: {}", path.display()))
     }
 }

--- a/src/query/regex_cache.rs
+++ b/src/query/regex_cache.rs
@@ -7,7 +7,8 @@ static REGEX_CACHE: OnceLock<Mutex<LruCache<String, Regex>>> = OnceLock::new();
 
 fn get_cache() -> &'static Mutex<LruCache<String, Regex>> {
     REGEX_CACHE.get_or_init(|| {
-        let capacity = NonZeroUsize::new(128).unwrap();
+        let capacity = NonZeroUsize::new(128)
+            .expect("128 is a valid non-zero capacity for regex cache");
         Mutex::new(LruCache::new(capacity))
     })
 }

--- a/src/query/regex_cache.rs
+++ b/src/query/regex_cache.rs
@@ -7,8 +7,8 @@ static REGEX_CACHE: OnceLock<Mutex<LruCache<String, Regex>>> = OnceLock::new();
 
 fn get_cache() -> &'static Mutex<LruCache<String, Regex>> {
     REGEX_CACHE.get_or_init(|| {
-        let capacity = NonZeroUsize::new(128)
-            .expect("128 is a valid non-zero capacity for regex cache");
+        let capacity =
+            NonZeroUsize::new(128).expect("128 is a valid non-zero capacity for regex cache");
         Mutex::new(LruCache::new(capacity))
     })
 }

--- a/src/search/async_engine.rs
+++ b/src/search/async_engine.rs
@@ -90,7 +90,10 @@ impl AsyncSearchEngine {
                         Ok(permit) => permit,
                         Err(e) => {
                             if options.verbose {
-                                debug!("Failed to acquire semaphore permit for file {:?}: {}", file_path, e);
+                                debug!(
+                                    "Failed to acquire semaphore permit for file {:?}: {}",
+                                    file_path, e
+                                );
                             }
                             return;
                         }
@@ -116,7 +119,9 @@ impl AsyncSearchEngine {
 
         let duration = start.elapsed();
         let results = Arc::try_unwrap(results)
-            .map_err(|_| anyhow::anyhow!("Failed to unwrap results - Arc still has active references"))?
+            .map_err(|_| {
+                anyhow::anyhow!("Failed to unwrap results - Arc still has active references")
+            })?
             .into_inner();
         let total = total_count.load(std::sync::atomic::Ordering::Relaxed);
 


### PR DESCRIPTION
## Summary
This PR fixes all 4 instances of `unwrap()` in production code as identified in #23, preventing potential runtime panics.

## Changes
- **cache_service.rs (HIGH priority)**: Replace unwrap() with proper error handling using `ok_or_else()`
- **async_engine.rs - semaphore (MEDIUM priority)**: Handle semaphore acquisition failure gracefully
- **async_engine.rs - Arc (LOW-MEDIUM priority)**: Add error handling for Arc::try_unwrap
- **regex_cache.rs (LOW priority)**: Use `expect()` with descriptive message for clarity

## Test Results
- ✅ All 341 tests passing
- ✅ No compilation errors
- ✅ `cargo clippy` shows no warnings

Fixes #23