### PR TITLE
Fix: Persist filters and sort order across mode transitions

### DIFF
--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -239,6 +239,11 @@ impl AppState {
                     Some(r) if r == "assistant" => Some("system".to_string()),
                     _ => None,
                 };
+                // Update navigation history to preserve filter state
+                if self.navigation_history.current_position().is_some() {
+                    self.navigation_history
+                        .update_current(self.create_navigation_state());
+                }
                 Command::ExecuteSearch
             }
             Message::ToggleSearchOrder => {
@@ -246,6 +251,11 @@ impl AppState {
                     SearchOrder::Descending => SearchOrder::Ascending,
                     SearchOrder::Ascending => SearchOrder::Descending,
                 };
+                // Update navigation history to preserve sort order
+                if self.navigation_history.current_position().is_some() {
+                    self.navigation_history
+                        .update_current(self.create_navigation_state());
+                }
                 // Re-execute the search with the new order to get different results
                 Command::ExecuteSearch
             }
@@ -285,6 +295,11 @@ impl AppState {
                 };
                 // Re-apply filter with new order
                 self.update_session_filter();
+                // Update navigation history to preserve sort order
+                if self.navigation_history.current_position().is_some() {
+                    self.navigation_history
+                        .update_current(self.create_navigation_state());
+                }
                 Command::None
             }
             Message::ToggleSessionRoleFilter => {
@@ -296,6 +311,11 @@ impl AppState {
                 };
                 // Re-apply filter with new role
                 self.update_session_filter();
+                // Update navigation history to preserve filter state
+                if self.navigation_history.current_position().is_some() {
+                    self.navigation_history
+                        .update_current(self.create_navigation_state());
+                }
                 Command::None
             }
             Message::SetStatus(msg) => {


### PR DESCRIPTION
## Summary
This PR fixes the issue where filters and sort order were being reset when navigating between modes in the interactive UI.

## Problem
Previously, when users applied filters (role filter, sort order) and then navigated to different modes (e.g., from Search to Result Detail and back), their filter settings would be lost. This created a poor user experience as users had to repeatedly reapply their preferred filters.

## Solution
The fix updates the navigation history whenever filters or sort order are changed, ensuring these settings are preserved across mode transitions.

### Changes made:
- Added `navigation_history.update_current()` calls in filter toggle handlers:
  - `ToggleRoleFilter` - Updates when search role filter changes
  - `ToggleSearchOrder` - Updates when search sort order changes  
  - `ToggleSessionOrder` - Updates when session viewer sort order changes
  - `ToggleSessionRoleFilter` - Updates when session viewer role filter changes
- Added comprehensive test cases to verify filter persistence behavior
- Fixed clippy warnings by using `.is_some()` instead of `if let Some(_)`

## Testing
- Added 3 new test cases covering different filter persistence scenarios
- All existing tests continue to pass
- Manual testing confirmed filters are now properly preserved

Fixes #85