### PR TITLE
feat: display role filter status in session viewer search bar

### DIFF
--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -205,9 +205,16 @@ impl SessionViewer {
             let search_text = self.text_input.render_cursor_spans();
             let order_text = Self::format_order(&self.order);
 
+            // Build status text with order and optional role filter
+            let status_text = if let Some(role) = &self.role_filter {
+                format!("Order: {order_text}, Role: {role}")
+            } else {
+                format!("Order: {order_text}")
+            };
+
             let search_bar = Paragraph::new(Line::from(search_text)).block(
                 Block::default()
-                    .title(format!("Search in session (Order: {order_text}) | Tab: Role Filter | Ctrl+O: Sort | Esc to cancel | ↑/↓ or Ctrl+P/N to scroll"))
+                    .title(format!("Search in session ({status_text}) | Tab: Role Filter | Ctrl+O: Sort | Esc to cancel | ↑/↓ or Ctrl+P/N to scroll"))
                     .borders(Borders::ALL)
                     .border_style(Style::default().fg(ColorScheme::SECONDARY)),
             );


### PR DESCRIPTION
## Summary
- Add role filter status display in the session viewer search bar header
- Shows active filters during search operations for better visibility
- Format: "Search in session (Order: Asc, Role: user)" when filtered

## Changes
- Modified  to include role filter in the search bar title
- Role filter is displayed within parentheses along with the order
- Only shows role filter when one is actively applied

## Test plan
- [x] All existing tests pass
- [x] Manual testing shows correct filter display
- [x] Filter status updates correctly when toggling role filters