### PR TITLE
Fix text truncation in interactive UI

### DIFF
--- a/src/interactive_ratatui/domain/session_list_item.rs
+++ b/src/interactive_ratatui/domain/session_list_item.rs
@@ -1,5 +1,5 @@
 use crate::interactive_ratatui::ui::components::list_item::{
-    ListItem, highlight_text, truncate_message, wrap_text,
+    ListItem, highlight_text, wrap_text,
 };
 use ratatui::style::{Color, Style};
 use ratatui::text::{Line, Span};
@@ -101,9 +101,10 @@ impl ListItem for SessionListItem {
         &self.content
     }
 
-    fn create_truncated_line(&self, max_width: usize, query: &str) -> Line<'static> {
+    fn create_truncated_line(&self, query: &str) -> Line<'static> {
         let timestamp = self.format_timestamp();
-        let content = truncate_message(self.get_content(), max_width);
+        // Let ratatui handle truncation - just remove newlines
+        let content = self.get_content().replace('\n', " ");
         let highlighted_content = highlight_text(&content, query);
 
         let mut spans = vec![

--- a/src/interactive_ratatui/ui/components/list_item.rs
+++ b/src/interactive_ratatui/ui/components/list_item.rs
@@ -38,7 +38,7 @@ pub trait ListItem: Clone {
     }
 
     /// Creates the display lines for truncated mode
-    fn create_truncated_line(&self, max_width: usize, query: &str) -> Line<'static>;
+    fn create_truncated_line(&self, query: &str) -> Line<'static>;
 
     /// Creates the display lines for full text mode
     fn create_full_lines(&self, max_width: usize, query: &str) -> Vec<Line<'static>>;

--- a/src/interactive_ratatui/ui/components/list_viewer.rs
+++ b/src/interactive_ratatui/ui/components/list_viewer.rs
@@ -382,7 +382,7 @@ impl<T: ListItem> ListViewer<T> {
 
                         if self.truncation_enabled {
                             TuiListItem::new(
-                                item.create_truncated_line(available_text_width, &self.query),
+                                item.create_truncated_line(&self.query),
                             )
                             .style(style)
                         } else {

--- a/src/interactive_ratatui/ui/components/list_viewer.rs
+++ b/src/interactive_ratatui/ui/components/list_viewer.rs
@@ -351,8 +351,8 @@ impl<T: ListItem> ListViewer<T> {
         let inner_area = block.inner(area);
         let available_height = inner_area.height;
         self.last_viewport_height = available_height;
-        self.adjust_scroll_offset(available_height, area.width);
-        let (start, end) = self.calculate_visible_range(available_height, area.width);
+        self.adjust_scroll_offset(available_height, inner_area.width);
+        let (start, end) = self.calculate_visible_range(available_height, inner_area.width);
 
         // Use Layout API to calculate available width for text
         let row_layout = Layout::default()
@@ -363,7 +363,7 @@ impl<T: ListItem> ListViewer<T> {
                 Constraint::Length(SEPARATOR_WIDTH),
                 Constraint::Min(MIN_MESSAGE_WIDTH),
             ])
-            .split(Rect::new(0, 0, area.width, 1));
+            .split(Rect::new(0, 0, inner_area.width, 1));
         let available_text_width = row_layout[3].width as usize;
 
         let items: Vec<TuiListItem> = (start..end)

--- a/src/interactive_ratatui/ui/components/list_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/list_viewer_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use super::super::list_item::{ListItem, truncate_message, wrap_text};
+    use super::super::list_item::{ListItem, wrap_text};
     use super::super::list_viewer::ListViewer;
     use ratatui::text::Line;
 
@@ -25,8 +25,9 @@ mod tests {
             &self.content
         }
 
-        fn create_truncated_line(&self, max_width: usize, _query: &str) -> Line<'static> {
-            let content = truncate_message(self.get_content(), max_width);
+        fn create_truncated_line(&self, _query: &str) -> Line<'static> {
+            // Let ratatui handle truncation
+            let content = self.get_content().replace('\n', " ");
             Line::from(content)
         }
 

--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -151,7 +151,7 @@ pub struct SearchResult {
 }
 
 use crate::interactive_ratatui::ui::components::list_item::{
-    ListItem, truncate_message, wrap_text,
+    ListItem, wrap_text,
 };
 use ratatui::style::{Color, Modifier, Style};
 use ratatui::text::{Line, Span};
@@ -169,16 +169,10 @@ impl ListItem for SearchResult {
         &self.text
     }
 
-    fn create_truncated_line(&self, max_width: usize, _query: &str) -> Line<'static> {
+    fn create_truncated_line(&self, _query: &str) -> Line<'static> {
         let timestamp = self.format_timestamp();
-        let content_raw = self.get_content().replace('\n', " ");
-        
-        // Only truncate if the content is actually longer than available width
-        let content = if content_raw.chars().count() > max_width {
-            truncate_message(&content_raw, max_width)
-        } else {
-            content_raw.clone()
-        };
+        // Let ratatui handle truncation - just remove newlines
+        let content = self.get_content().replace('\n', " ");
 
         let mut spans = vec![
             Span::styled(

--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -171,7 +171,14 @@ impl ListItem for SearchResult {
 
     fn create_truncated_line(&self, max_width: usize, _query: &str) -> Line<'static> {
         let timestamp = self.format_timestamp();
-        let content = truncate_message(self.get_content(), max_width);
+        let content_raw = self.get_content().replace('\n', " ");
+        
+        // Only truncate if the content is actually longer than available width
+        let content = if content_raw.chars().count() > max_width {
+            truncate_message(&content_raw, max_width)
+        } else {
+            content_raw.clone()
+        };
 
         let mut spans = vec![
             Span::styled(


### PR DESCRIPTION
## Summary
This PR improves text truncation handling in the interactive UI by:
- Fixing the calculation of available width to properly account for UI borders
- Allowing ratatui to handle text overflow naturally instead of manual truncation

## Changes Made
1. **Fixed width calculation**: Changed from using `area.width` to `inner_area.width` to correctly account for borders when calculating available text space
2. **Removed manual truncation**: Removed the manual text truncation logic in `create_truncated_line` methods and let ratatui handle text overflow naturally
3. **Simplified code**: Removed the `max_width` parameter from `create_truncated_line` method as it's no longer needed
4. **Cleaned up imports**: Removed unused `truncate_message` imports

## Problem Solved
Previously, text was being truncated too aggressively because the width calculation included the border width. This caused text to be cut off unnecessarily even when there was available space.

## Testing
- All existing tests pass
- No compilation warnings
- The interactive UI now properly displays text without unnecessary truncation