### PR TITLE
refactor: remove result count from search results display

### DIFF
--- a/src/interactive_ratatui/ui/components/result_list.rs
+++ b/src/interactive_ratatui/ui/components/result_list.rs
@@ -65,7 +65,7 @@ impl Component for ResultList {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(3), // Title
+                Constraint::Length(2), // Title
                 Constraint::Min(0),    // Content (list)
                 Constraint::Length(2), // Status
             ])
@@ -74,10 +74,6 @@ impl Component for ResultList {
         // Render title
         let title_lines = vec![
             Line::from(vec![Span::styled("Search Results", Styles::title())]),
-            Line::from(vec![Span::raw(format!(
-                "{} results found",
-                self.list_viewer.filtered_count()
-            ))]),
         ];
         let title = Paragraph::new(title_lines).block(Block::default().borders(Borders::BOTTOM));
         f.render_widget(title, chunks[0]);

--- a/src/interactive_ratatui/ui/components/result_list.rs
+++ b/src/interactive_ratatui/ui/components/result_list.rs
@@ -72,9 +72,10 @@ impl Component for ResultList {
             .split(area);
 
         // Render title
-        let title_lines = vec![
-            Line::from(vec![Span::styled("Search Results", Styles::title())]),
-        ];
+        let title_lines = vec![Line::from(vec![Span::styled(
+            "Search Results",
+            Styles::title(),
+        )])];
         let title = Paragraph::new(title_lines).block(Block::default().borders(Borders::BOTTOM));
         f.render_widget(title, chunks[0]);
 


### PR DESCRIPTION
## Summary
- Removed the "X results found" text from the search results UI
- Optimized the title area layout for better space utilization

## Changes
- Removed the result count line from `ResultList` component
- Reduced title area height from 3 lines to 2 lines, providing more space for actual search results

## Motivation
Simplify the search results interface by removing redundant information. The result count was taking up valuable screen space without providing essential functionality.

## Test Plan
- [x] Manual testing: Verified that search results display correctly without the count
- [x] UI still functions as expected with all keyboard shortcuts working
- [ ] CI/CD tests pass