### PR TITLE
fix: navigate to result detail on Enter in session viewer search mode

### DIFF
--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -379,7 +379,16 @@ impl Component for SessionViewer {
                 }
                 KeyCode::Enter => {
                     self.is_searching = false;
-                    None
+                    // Navigate to result detail for selected message
+                    self.list_viewer.get_selected_item().and_then(|item| {
+                        self.file_path.as_ref().map(|path| {
+                            Message::EnterResultDetailFromSession(
+                                item.raw_json.clone(),
+                                path.clone(),
+                                self.session_id.clone(),
+                            )
+                        })
+                    })
                 }
                 KeyCode::Up => {
                     self.list_viewer.move_up();


### PR DESCRIPTION
## Summary
This PR fixes the Enter key behavior in session viewer's search mode to navigate to the selected message's result detail view.

## Problem
Previously, pressing Enter while in search mode (`/` command) would only exit search mode without performing any navigation action. This was inconsistent with the non-search mode behavior where Enter navigates to the result detail.

## Solution
Modified the Enter key handler in search mode to:
1. Exit search mode (preserving existing behavior)
2. Navigate to the selected message's result detail view (new behavior)

This change reuses the same navigation logic as the non-search mode, ensuring consistent behavior across different modes.

## Test Plan
1. Open session viewer
2. Press `/` to enter search mode
3. Type a search query to filter messages
4. Use arrow keys to select a message
5. Press Enter
6. Verify that it navigates to the result detail view of the selected message

## Impact
- Improves user experience by making Enter key behavior consistent
- No breaking changes - only adds navigation functionality to an existing key binding