### PR TITLE
refactor: rename ResultDetail to MessageDetail for clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,7 +139,7 @@ The codebase is organized into five main modules:
   - **Update**: Message-driven state updates with side effects as `Command`s
 - **Component-Based UI**:
   - Reusable components implementing `Component` trait
-  - `SearchBar`, `ResultList`, `ResultDetail`, `SessionViewer`, `HelpDialog`
+  - `SearchBar`, `ResultList`, `MessageDetail`, `SessionViewer`, `HelpDialog`
   - Each component manages its own rendering and input handling
 - **Non-blocking Architecture**:
   - Event polling with 50ms timeout
@@ -233,7 +233,7 @@ The interactive mode uses non-blocking input handling to prevent UI freezing:
 - Dynamic text truncation respects character boundaries
 
 **State Management**:
-- Clear separation between UI modes (Search, ResultDetail, SessionViewer, Help)
+- Clear separation between UI modes (Search, MessageDetail, SessionViewer, Help)
 - Automatic cleanup on mode transitions (clear messages, reset scroll)
 - Comprehensive caching system to minimize file I/O
 
@@ -329,7 +329,7 @@ src/interactive_ratatui/
     └── components/          # Reusable UI components
         ├── search_bar.rs
         ├── result_list.rs
-        ├── result_detail.rs
+        ├── message_detail.rs
         ├── session_viewer.rs
         └── help_dialog.rs
 ```
@@ -338,7 +338,7 @@ src/interactive_ratatui/
 
 1. **Messages** (`ui/events.rs`):
    - User actions and system events
-   - Examples: `QueryChanged`, `SearchCompleted`, `EnterResultDetail`
+   - Examples: `QueryChanged`, `SearchCompleted`, `EnterMessageDetail`
 
 2. **State** (`ui/app_state.rs`):
    - Single source of truth for UI state

--- a/README.md
+++ b/README.md
@@ -153,13 +153,13 @@ ccms -i -n 100                               # Adjust result limit
 - Results are limited by the `-n` flag (default: 50, but 20x more are loaded for scrolling)
 
 **Result Actions:**
-- `Enter` - View result details
+- `Enter` - View message details
 - `Ctrl+S` - Jump directly to session viewer
 - `Tab` - Toggle role filter (all → user → assistant → system)
 - `Ctrl+O` - Toggle sort order (newest/oldest first)
 - `Ctrl+T` - Toggle message truncation
 
-**Result Detail & Session Viewer Copy Operations (Unified):**
+**Message Detail & Session Viewer Copy Operations (Unified):**
 - `c` - Copy content/text
 - `C` - Copy as JSON
 - `i` - Copy session ID

--- a/benches/interactive_ui_benchmark.rs
+++ b/benches/interactive_ui_benchmark.rs
@@ -271,7 +271,7 @@ fn benchmark_app_state_updates(c: &mut Criterion) {
                 state
             },
             |mut state| {
-                let msg = Message::EnterResultDetail;
+                let msg = Message::EnterMessageDetail;
                 black_box(state.update(msg));
             },
             BatchSize::SmallInput,
@@ -337,7 +337,7 @@ fn benchmark_full_frame_rendering(c: &mut Criterion) {
         let mut state = AppState::new();
         let test_results = create_test_search_results(10);
         state.ui.selected_result = Some(test_results[0].clone());
-        state.mode = ccms::interactive_ratatui::ui::app_state::Mode::ResultDetail;
+        state.mode = ccms::interactive_ratatui::ui::app_state::Mode::MessageDetail;
 
         b.iter_batched(
             || TestBackend::new(120, 40),

--- a/spec.md
+++ b/spec.md
@@ -137,7 +137,7 @@ When 'S' is pressed in the full result view:
 Enter: View | ↑/↓ or Ctrl+P/N: Navigate | Ctrl+U/D: Half-page | Tab: Role Filter | /: Search | c/C/i/f/p: Copy | Ctrl+O: Sort | Esc: Back
 ```
 
-**Navigation**: Pressing Esc returns to the previous screen (typically ResultDetail), not directly to Search.
+**Navigation**: Pressing Esc returns to the previous screen (typically MessageDetail), not directly to Search.
 
 #### Session Viewer Features
 
@@ -305,7 +305,7 @@ Applied before other filters in the search pipeline.
   - Session IDs (UUID format): "✓ Copied session ID"
   - Short text (< 100 chars): "✓ Copied: [actual text]"
   - Long text: "✓ Copied message text"
-  - Full result details: "✓ Copied full result details"
+  - Full message details: "✓ Copied full message details"
 
 ## Display Limits
 
@@ -359,7 +359,7 @@ The Ctrl+T keyboard shortcut toggles between truncated and full text display mod
 - Mode persists across search and session viewer
 - Feedback message shown when toggling
 
-Note: The Result Detail view always displays messages with word wrapping and is not affected by the truncation toggle.
+Note: The Message Detail view always displays messages with word wrapping and is not affected by the truncation toggle.
 
 ### Session Viewer Display Limits
 
@@ -438,7 +438,7 @@ The interactive mode uses a Model-View-Update (MVU) architecture with clean sepa
 ### Architecture Layers
 
 1. **Domain Layer**: Core business entities and models
-   - `Mode`: Current UI screen (Search, ResultDetail, SessionViewer, Help)
+   - `Mode`: Current UI screen (Search, MessageDetail, SessionViewer, Help)
    - `SearchRequest`: Query and filter parameters
    - `SessionOrder`: Sort order for session messages
 
@@ -505,10 +505,10 @@ The interactive mode maintains a navigation history stack that allows users to r
 
 ### Mode Transitions
 
-- Search → ResultDetail: Enter key on result (pushes to stack)
-- ResultDetail → Search: Esc or other keys (pops from stack, clears message and scroll offset)
-- ResultDetail → SessionViewer: S key (pushes to stack)
-- SessionViewer → ResultDetail: Q/Esc (pops from stack, returns to previous screen)
+- Search → MessageDetail: Enter key on result (pushes to stack)
+- MessageDetail → Search: Esc or other keys (pops from stack, clears message and scroll offset)
+- MessageDetail → SessionViewer: S key (pushes to stack)
+- SessionViewer → MessageDetail: Q/Esc (pops from stack, returns to previous screen)
 - Any → Help: ? key (pushes to stack)
 - Help → Previous Screen: Any key (pops from stack)
 
@@ -525,7 +525,7 @@ When entering SessionViewer:
 
 When exiting SessionViewer:
 - Clears all session-related state
-- Returns to ResultDetail mode
+- Returns to MessageDetail mode
 - Preserves the selected result for continued navigation
 
 ## Project Path Extraction
@@ -562,5 +562,5 @@ Recent enhancements include:
 - Non-blocking UI with visual feedback during operations
 - Unicode-safe text handling throughout
 - Search result highlighting in Session Viewer
-- Automatic text wrapping for long file paths in Result Detail and Session Viewer
+- Automatic text wrapping for long file paths in Message Detail and Session Viewer
 - Unified exit mechanism (Ctrl+C twice) - ESC no longer exits from search screen

--- a/src/interactive_ratatui/domain/models.rs
+++ b/src/interactive_ratatui/domain/models.rs
@@ -5,7 +5,7 @@ use std::time::SystemTime;
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum Mode {
     Search,
-    ResultDetail,
+    MessageDetail,
     SessionViewer,
     Help,
 }

--- a/src/interactive_ratatui/domain/models_test.rs
+++ b/src/interactive_ratatui/domain/models_test.rs
@@ -6,7 +6,7 @@ mod tests {
     fn test_mode_equality() {
         assert_eq!(Mode::Search, Mode::Search);
         assert_ne!(Mode::Search, Mode::Help);
-        assert_ne!(Mode::ResultDetail, Mode::SessionViewer);
+        assert_ne!(Mode::MessageDetail, Mode::SessionViewer);
     }
 
     #[test]

--- a/src/interactive_ratatui/help_navigation_test.rs
+++ b/src/interactive_ratatui/help_navigation_test.rs
@@ -26,21 +26,21 @@ mod tests {
     fn test_help_dialog_navigation_from_result_detail_mode() {
         let mut state = AppState::new();
 
-        // First navigate to result detail mode
+        // First navigate to message detail mode
         // (We need to set up a result first)
         state.search.results = vec![create_test_result()];
-        state.update(Message::EnterResultDetail);
-        assert_eq!(state.mode, Mode::ResultDetail);
+        state.update(Message::EnterMessageDetail);
+        assert_eq!(state.mode, Mode::MessageDetail);
         assert_eq!(state.navigation_history.len(), 2); // Search + ResultDetail
 
-        // Show help from result detail mode
+        // Show help from message detail mode
         state.update(Message::ShowHelp);
         assert_eq!(state.mode, Mode::Help);
         assert_eq!(state.navigation_history.len(), 3); // Search + ResultDetail + Help
 
-        // Close help should return to result detail mode
+        // Close help should return to message detail mode
         state.update(Message::CloseHelp);
-        assert_eq!(state.mode, Mode::ResultDetail);
+        assert_eq!(state.mode, Mode::MessageDetail);
         assert!(state.navigation_history.can_go_back()); // Can go back to Search
         assert!(state.navigation_history.can_go_forward()); // Can go forward to Help
     }
@@ -93,7 +93,7 @@ mod tests {
 
         // Navigate: Search -> ResultDetail -> SessionViewer -> Help
         state.search.results = vec![create_test_result()];
-        state.update(Message::EnterResultDetail);
+        state.update(Message::EnterMessageDetail);
         assert_eq!(state.navigation_history.len(), 2); // Search + ResultDetail
 
         state.update(Message::EnterSessionViewer);
@@ -107,9 +107,9 @@ mod tests {
         state.update(Message::CloseHelp);
         assert_eq!(state.mode, Mode::SessionViewer);
 
-        // Navigate back to result detail
+        // Navigate back to message detail
         state.update(Message::ExitToSearch);
-        assert_eq!(state.mode, Mode::ResultDetail);
+        assert_eq!(state.mode, Mode::MessageDetail);
 
         // Navigate back to search
         state.update(Message::ExitToSearch);
@@ -125,7 +125,7 @@ mod tests {
 
         // Navigate: Search -> ResultDetail -> SessionViewer
         state.search.results = vec![create_test_result()];
-        state.update(Message::EnterResultDetail);
+        state.update(Message::EnterMessageDetail);
         assert_eq!(state.navigation_history.len(), 2); // Search + ResultDetail
 
         state.update(Message::EnterSessionViewer);
@@ -134,7 +134,7 @@ mod tests {
 
         // Navigate back from SessionViewer to ResultDetail
         state.update(Message::NavigateBack);
-        assert_eq!(state.mode, Mode::ResultDetail);
+        assert_eq!(state.mode, Mode::MessageDetail);
         assert!(state.navigation_history.can_go_back());
         assert!(state.navigation_history.can_go_forward());
 
@@ -146,7 +146,7 @@ mod tests {
 
         // Navigate forward - goes to ResultDetail
         state.update(Message::NavigateForward);
-        assert_eq!(state.mode, Mode::ResultDetail);
+        assert_eq!(state.mode, Mode::MessageDetail);
         assert!(state.navigation_history.can_go_back());
         assert!(state.navigation_history.can_go_forward());
 

--- a/src/interactive_ratatui/integration_tests.rs
+++ b/src/interactive_ratatui/integration_tests.rs
@@ -340,8 +340,8 @@ mod tests {
             .unwrap();
         assert!(!should_exit);
 
-        // ESC in result detail should return to search
-        app.state.mode = Mode::ResultDetail;
+        // ESC in message detail should return to search
+        app.state.mode = Mode::MessageDetail;
         let should_exit = app
             .handle_input(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
             .unwrap();
@@ -354,8 +354,8 @@ mod tests {
         app.state.search.results = vec![create_test_result("user", "test", "2024-01-01T00:00:00Z")];
 
         // Navigate to ResultDetail (this will save both Search and ResultDetail states)
-        app.handle_message(Message::EnterResultDetail);
-        assert_eq!(app.state.mode, Mode::ResultDetail);
+        app.handle_message(Message::EnterMessageDetail);
+        assert_eq!(app.state.mode, Mode::MessageDetail);
 
         // Navigate to SessionViewer (this will save SessionViewer state)
         app.handle_message(Message::EnterSessionViewer);
@@ -366,7 +366,7 @@ mod tests {
             .handle_input(KeyEvent::new(KeyCode::Esc, KeyModifiers::empty()))
             .unwrap();
         assert!(!should_exit);
-        assert_eq!(app.state.mode, Mode::ResultDetail);
+        assert_eq!(app.state.mode, Mode::MessageDetail);
     }
 
     /// Test navigation history functionality
@@ -378,10 +378,10 @@ mod tests {
         app.state.mode = Mode::Search;
         assert!(app.state.navigation_history.is_empty());
 
-        // Navigate to result detail
+        // Navigate to message detail
         app.state.search.results = vec![create_test_result("user", "test", "2024-01-01T00:00:00Z")];
-        app.handle_message(Message::EnterResultDetail);
-        assert_eq!(app.state.mode, Mode::ResultDetail);
+        app.handle_message(Message::EnterMessageDetail);
+        assert_eq!(app.state.mode, Mode::MessageDetail);
         assert_eq!(app.state.navigation_history.len(), 2); // Search and ResultDetail
 
         // Navigate to session viewer
@@ -389,9 +389,9 @@ mod tests {
         assert_eq!(app.state.mode, Mode::SessionViewer);
         assert_eq!(app.state.navigation_history.len(), 3); // Search, ResultDetail, SessionViewer
 
-        // ESC should pop back to result detail
+        // ESC should pop back to message detail
         app.handle_message(Message::ExitToSearch);
-        assert_eq!(app.state.mode, Mode::ResultDetail);
+        assert_eq!(app.state.mode, Mode::MessageDetail);
         assert!(app.state.navigation_history.can_go_forward());
 
         // Another ESC should go back to search
@@ -449,7 +449,7 @@ mod tests {
 
         // Now push ResultDetail state
         let result_detail_state = NavigationState {
-            mode: Mode::ResultDetail,
+            mode: Mode::MessageDetail,
             search_state: SearchStateSnapshot {
                 query: String::new(),
                 results: Vec::new(),
@@ -495,7 +495,7 @@ mod tests {
         let forward_state = history.go_forward();
         assert_eq!(
             forward_state.unwrap().mode,
-            Mode::ResultDetail,
+            Mode::MessageDetail,
             "go_forward returns ResultDetail"
         );
         assert!(history.can_go_back());
@@ -529,8 +529,8 @@ mod tests {
         app.state.search.results = vec![create_test_result("user", "test", "2024-01-01T00:00:00Z")];
 
         // Navigate to ResultDetail - this will push both Search and ResultDetail states
-        app.handle_message(Message::EnterResultDetail);
-        assert_eq!(app.state.mode, Mode::ResultDetail);
+        app.handle_message(Message::EnterMessageDetail);
+        assert_eq!(app.state.mode, Mode::MessageDetail);
         assert!(
             app.state.ui.selected_result.is_some(),
             "Should have selected result"
@@ -572,7 +572,7 @@ mod tests {
         app.handle_input(alt_right).unwrap();
         assert_eq!(
             app.state.mode,
-            Mode::ResultDetail,
+            Mode::MessageDetail,
             "Alt+Right should go forward to ResultDetail"
         );
         assert!(
@@ -588,7 +588,7 @@ mod tests {
         app.handle_input(alt_right).unwrap();
         assert_eq!(
             app.state.mode,
-            Mode::ResultDetail,
+            Mode::MessageDetail,
             "Alt+Right at end should not change mode"
         );
     }
@@ -604,8 +604,8 @@ mod tests {
 
         // Setup: Navigate through modes
         app.state.search.results = vec![create_test_result("user", "test", "2024-01-01T00:00:00Z")];
-        app.handle_message(Message::EnterResultDetail);
-        assert_eq!(app.state.mode, Mode::ResultDetail);
+        app.handle_message(Message::EnterMessageDetail);
+        assert_eq!(app.state.mode, Mode::MessageDetail);
         assert_eq!(app.state.navigation_history.len(), 2); // Search, ResultDetail
 
         app.handle_message(Message::EnterSessionViewer);
@@ -616,7 +616,7 @@ mod tests {
         app.handle_input(alt_left).unwrap();
         assert_eq!(
             app.state.mode,
-            Mode::ResultDetail,
+            Mode::MessageDetail,
             "Alt+Left from SessionViewer should go to ResultDetail"
         );
 
@@ -631,7 +631,7 @@ mod tests {
         app.handle_input(alt_right).unwrap();
         assert_eq!(
             app.state.mode,
-            Mode::ResultDetail,
+            Mode::MessageDetail,
             "Alt+Right should go to ResultDetail"
         );
 
@@ -751,9 +751,9 @@ mod tests {
         let mut app = InteractiveSearch::new(SearchOptions::default());
         let result = create_test_result("user", "Test message", "2024-01-01T12:00:00Z");
 
-        app.state.mode = Mode::ResultDetail;
+        app.state.mode = Mode::MessageDetail;
         app.state.ui.selected_result = Some(result.clone());
-        app.renderer.get_result_detail_mut().set_result(result);
+        app.renderer.get_message_detail_mut().set_result(result);
 
         // Render and check metadata is displayed
         let backend = TestBackend::new(100, 40);
@@ -838,9 +838,9 @@ mod tests {
         let mut app = InteractiveSearch::new(SearchOptions::default());
         let result = create_test_result("user", "Test message", "2024-01-01T00:00:00Z");
 
-        app.state.mode = Mode::ResultDetail;
+        app.state.mode = Mode::MessageDetail;
         app.state.ui.selected_result = Some(result.clone());
-        app.renderer.get_result_detail_mut().set_result(result);
+        app.renderer.get_message_detail_mut().set_result(result);
 
         // Test all copy shortcuts
         let shortcuts = vec![
@@ -993,7 +993,7 @@ mod tests {
     fn test_ctrl_c_in_all_modes() {
         let modes = vec![
             Mode::Search,
-            Mode::ResultDetail,
+            Mode::MessageDetail,
             Mode::SessionViewer,
             Mode::Help,
         ];

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -206,7 +206,7 @@ impl InteractiveSearch {
         // Mode-specific input handling
         let message = match self.state.mode {
             Mode::Search => self.handle_search_mode_input(key),
-            Mode::ResultDetail => self.renderer.get_result_detail_mut().handle_key(key),
+            Mode::MessageDetail => self.renderer.get_message_detail_mut().handle_key(key),
             Mode::SessionViewer => self.renderer.get_session_viewer_mut().handle_key(key),
             Mode::Help => self.renderer.get_help_dialog_mut().handle_key(key),
         };
@@ -288,8 +288,8 @@ impl InteractiveSearch {
                     ui::events::CopyContent::JsonData(json) => {
                         (json, "✓ Copied as JSON".to_string())
                     }
-                    ui::events::CopyContent::FullResultDetails(details) => {
-                        (details, "✓ Copied full result details".to_string())
+                    ui::events::CopyContent::FullMessageDetails(details) => {
+                        (details, "✓ Copied full message details".to_string())
                     }
                 };
 

--- a/src/interactive_ratatui/tests.rs
+++ b/src/interactive_ratatui/tests.rs
@@ -47,8 +47,8 @@ fn test_message_handling() {
         raw_json: None,
     }];
 
-    let command = state.update(Message::EnterResultDetail);
-    assert_eq!(state.mode, Mode::ResultDetail);
+    let command = state.update(Message::EnterMessageDetail);
+    assert_eq!(state.mode, Mode::MessageDetail);
     assert!(matches!(command, Command::None));
 }
 

--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -123,10 +123,10 @@ impl AppState {
                 // Scroll handling is now done within ResultList
                 Command::None
             }
-            Message::EnterResultDetail => {
+            Message::EnterMessageDetail => {
                 if let Some(result) = self.search.results.get(self.search.selected_index).cloned() {
                     // Only save state if we're actually changing modes
-                    if self.mode != Mode::ResultDetail {
+                    if self.mode != Mode::MessageDetail {
                         // If this is our first navigation, save the initial state
                         if self.navigation_history.is_empty() {
                             let initial_state = self.create_navigation_state();
@@ -142,7 +142,7 @@ impl AppState {
 
                         self.ui.selected_result = Some(result);
                         self.ui.detail_scroll_offset = 0;
-                        self.mode = Mode::ResultDetail;
+                        self.mode = Mode::MessageDetail;
 
                         // Save the new state after transitioning
                         let new_state = self.create_navigation_state();
@@ -156,7 +156,7 @@ impl AppState {
             }
             Message::EnterSessionViewer => {
                 // Try to get result from selected result (when in detail view) or search results
-                let result = if self.mode == Mode::ResultDetail {
+                let result = if self.mode == Mode::MessageDetail {
                     self.ui.selected_result.as_ref()
                 } else {
                     self.search.results.get(self.search.selected_index)
@@ -326,7 +326,7 @@ impl AppState {
                 self.ui.message = None;
                 Command::None
             }
-            Message::EnterResultDetailFromSession(raw_json, file_path, session_id) => {
+            Message::EnterMessageDetailFromSession(raw_json, file_path, session_id) => {
                 // Parse the raw JSON to create a SearchResult
                 if let Ok(json_value) = serde_json::from_str::<serde_json::Value>(&raw_json) {
                     let role = json_value
@@ -421,7 +421,7 @@ impl AppState {
 
                     self.ui.selected_result = Some(result);
                     self.ui.detail_scroll_offset = 0;
-                    self.mode = Mode::ResultDetail;
+                    self.mode = Mode::MessageDetail;
 
                     // Save the new state after transitioning
                     let new_state = self.create_navigation_state();
@@ -613,7 +613,7 @@ impl AppState {
                     Command::None
                 }
             }
-            Mode::ResultDetail => {
+            Mode::MessageDetail => {
                 // ResultDetail initialization during direct transition:
                 // - Selected result is set in EnterResultDetail handler
                 // - Scroll position is reset here for consistency

--- a/src/interactive_ratatui/ui/app_state_test.rs
+++ b/src/interactive_ratatui/ui/app_state_test.rs
@@ -102,9 +102,9 @@ mod tests {
         let mut state = create_test_state();
         state.search.results = vec![create_test_result()];
 
-        // Enter result detail
-        let _command = state.update(Message::EnterResultDetail);
-        assert_eq!(state.mode, Mode::ResultDetail);
+        // Enter message detail
+        let _command = state.update(Message::EnterMessageDetail);
+        assert_eq!(state.mode, Mode::MessageDetail);
         assert!(state.ui.selected_result.is_some());
 
         // Exit back to search
@@ -321,8 +321,8 @@ mod tests {
         state.search.results = results.clone();
 
         // Navigate to ResultDetail
-        state.update(Message::EnterResultDetail);
-        assert_eq!(state.mode, Mode::ResultDetail);
+        state.update(Message::EnterMessageDetail);
+        assert_eq!(state.mode, Mode::MessageDetail);
 
         // Navigate back to Search
         state.update(Message::ExitToSearch);
@@ -349,12 +349,12 @@ mod tests {
 
         // Navigate to ResultDetail from session
         let raw_json = state.session.messages[0].clone();
-        state.update(Message::EnterResultDetailFromSession(
+        state.update(Message::EnterMessageDetailFromSession(
             raw_json,
             "test.jsonl".to_string(),
             Some("session-id".to_string()),
         ));
-        assert_eq!(state.mode, Mode::ResultDetail);
+        assert_eq!(state.mode, Mode::MessageDetail);
 
         // Navigate back to SessionViewer
         state.update(Message::ExitToSearch);
@@ -373,7 +373,7 @@ mod tests {
         state.search.results = vec![create_test_result()];
 
         // Navigate to ResultDetail to establish navigation history
-        state.update(Message::EnterResultDetail);
+        state.update(Message::EnterMessageDetail);
 
         // Go back to Search
         state.update(Message::ExitToSearch);
@@ -388,7 +388,7 @@ mod tests {
         assert_eq!(state.search.order, SearchOrder::Ascending);
 
         // Navigate to ResultDetail again
-        state.update(Message::EnterResultDetail);
+        state.update(Message::EnterMessageDetail);
 
         // Go back - should see both updated filter and order
         state.update(Message::ExitToSearch);

--- a/src/interactive_ratatui/ui/components/help_dialog.rs
+++ b/src/interactive_ratatui/ui/components/help_dialog.rs
@@ -70,7 +70,7 @@ impl HelpDialog {
             )]),
             Line::from("  ↑/↓         - Navigate results"),
             Line::from("  Ctrl+u/d    - Half-page scrolling (up/down)"),
-            Line::from("  Enter       - View result details"),
+            Line::from("  Enter       - View message details"),
             Line::from("  Ctrl+S      - Jump directly to session viewer"),
             Line::from("  Tab         - Toggle role filter (user/assistant/system)"),
             Line::from("  Ctrl+O      - Toggle sort order (newest/oldest first)"),
@@ -95,7 +95,7 @@ impl HelpDialog {
             Line::from("  Ctrl+H      - Delete character before cursor"),
             Line::from(""),
             Line::from(vec![Span::styled(
-                "Result Detail Mode:",
+                "Message Detail Mode:",
                 Style::default()
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::BOLD),

--- a/src/interactive_ratatui/ui/components/message_detail.rs
+++ b/src/interactive_ratatui/ui/components/message_detail.rs
@@ -14,13 +14,13 @@ use ratatui::{
 };
 
 #[derive(Default)]
-pub struct ResultDetail {
+pub struct MessageDetail {
     pub(super) result: Option<SearchResult>,
     pub(super) scroll_offset: usize,
     pub(super) message: Option<String>,
 }
 
-impl ResultDetail {
+impl MessageDetail {
     pub fn new() -> Self {
         Self {
             result: None,
@@ -224,13 +224,13 @@ impl ResultDetail {
     }
 }
 
-impl Component for ResultDetail {
+impl Component for MessageDetail {
     fn render(&mut self, f: &mut Frame, area: Rect) {
         let Some(_result) = &self.result else {
             return;
         };
 
-        let layout = ViewLayout::new("Result Detail".to_string()).with_status_bar(false); // We'll handle status manually for now
+        let layout = ViewLayout::new("Message Detail".to_string()).with_status_bar(false); // We'll handle status manually for now
 
         layout.render(f, area, |f, content_area| {
             self.render_content(f, content_area);
@@ -304,7 +304,7 @@ impl Component for ResultDetail {
                             result.text,
                             result.project_path
                         );
-                        Some(Message::CopyToClipboard(CopyContent::FullResultDetails(
+                        Some(Message::CopyToClipboard(CopyContent::FullMessageDetails(
                             formatted,
                         )))
                     }

--- a/src/interactive_ratatui/ui/components/message_detail_test.rs
+++ b/src/interactive_ratatui/ui/components/message_detail_test.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use super::super::result_detail::ResultDetail;
+    use super::super::message_detail::MessageDetail;
     use crate::interactive_ratatui::ui::components::Component;
     use crate::interactive_ratatui::ui::events::{CopyContent, Message};
     use crate::query::condition::{QueryCondition, SearchResult};
@@ -58,7 +58,7 @@ mod tests {
         result
     }
 
-    fn render_component(component: &mut ResultDetail, width: u16, height: u16) -> Buffer {
+    fn render_component(component: &mut MessageDetail, width: u16, height: u16) -> Buffer {
         let backend = TestBackend::new(width, height);
         let mut terminal = Terminal::new(backend).unwrap();
 
@@ -73,7 +73,7 @@ mod tests {
 
     #[test]
     fn test_result_detail_new() {
-        let detail = ResultDetail::new();
+        let detail = MessageDetail::new();
         assert!(detail.result.is_none());
         assert_eq!(detail.scroll_offset, 0);
         assert!(detail.message.is_none());
@@ -81,7 +81,7 @@ mod tests {
 
     #[test]
     fn test_set_result() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let result = create_test_result();
 
         detail.set_result(result.clone());
@@ -95,7 +95,7 @@ mod tests {
 
     #[test]
     fn test_clear() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let result = create_test_result();
 
         detail.set_result(result);
@@ -108,7 +108,7 @@ mod tests {
 
     #[test]
     fn test_set_message() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
 
         detail.set_message(Some("Test message".to_string()));
         assert_eq!(detail.message, Some("Test message".to_string()));
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn test_text_wrapping() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let result = create_test_result_with_long_text();
         detail.set_result(result);
 
@@ -134,7 +134,7 @@ mod tests {
             .collect::<String>();
 
         // Check that the component rendered
-        assert!(content.contains("Result Detail"));
+        assert!(content.contains("Message Detail"));
 
         // The header fields should be visible
         assert!(content.contains("Role:"));
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn test_long_file_path_wrapping() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let result = create_test_result_with_long_file_path();
         detail.set_result(result);
 
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn test_long_project_path_wrapping() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let result = create_test_result_with_long_project_path();
         detail.set_result(result);
 
@@ -197,7 +197,7 @@ mod tests {
 
     #[test]
     fn test_scroll_navigation() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let result = create_test_result();
         detail.set_result(result);
 
@@ -229,7 +229,7 @@ mod tests {
 
     #[test]
     fn test_page_navigation() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let result = create_test_result();
         detail.set_result(result);
 
@@ -252,7 +252,7 @@ mod tests {
 
     #[test]
     fn test_copy_shortcuts() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let result = create_test_result();
         detail.set_result(result);
 
@@ -289,7 +289,7 @@ mod tests {
 
     #[test]
     fn test_navigation_shortcuts() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let result = create_test_result();
         detail.set_result(result);
 
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_all_fields_wrapping() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let result = create_test_result_with_all_long_fields();
         detail.set_result(result);
 
@@ -338,7 +338,7 @@ mod tests {
 
     #[test]
     fn test_copy_without_result() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         // Don't set any result
 
         // All copy operations should return None when no result is set
@@ -363,7 +363,7 @@ mod tests {
 
     #[test]
     fn test_unicode_text_wrapping() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let mut result = create_test_result();
         result.text = "これは日本語のテストメッセージです。絵文字も含まれています🎉。長いテキストが正しく折り返されることを確認します。".to_string();
         detail.set_result(result);
@@ -379,7 +379,7 @@ mod tests {
 
     #[test]
     fn test_render_without_result() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
 
         // Should not panic when rendering without a result
         let buffer = render_component(&mut detail, 80, 24);
@@ -395,7 +395,7 @@ mod tests {
 
     #[test]
     fn test_copy_raw_json_fallback() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let mut result = create_test_result();
         result.raw_json = None; // No raw JSON available
         detail.set_result(result);
@@ -404,7 +404,7 @@ mod tests {
         let msg = detail.handle_key(KeyEvent::new(KeyCode::Char('C'), KeyModifiers::empty()));
         if let Some(Message::CopyToClipboard(content)) = msg {
             match content {
-                CopyContent::FullResultDetails(text) => {
+                CopyContent::FullMessageDetails(text) => {
                     assert!(text.contains("File: /path/to/test.jsonl"));
                     assert!(text.contains("UUID: 12345678-1234-5678-1234-567812345678"));
                     assert!(text.contains("Session ID: session-123"));
@@ -412,7 +412,7 @@ mod tests {
                     assert!(text.contains("Text: This is a test message"));
                     assert!(text.contains("Project: /path/to/project"));
                 }
-                _ => panic!("Expected FullResultDetails variant"),
+                _ => panic!("Expected FullMessageDetails variant"),
             }
         } else {
             panic!("Expected CopyToClipboard message");
@@ -421,7 +421,7 @@ mod tests {
 
     #[test]
     fn test_message_only_scrolling() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let mut result = create_test_result();
         // Create a long message that will need scrolling
         result.text = (0..50)
@@ -469,7 +469,7 @@ mod tests {
 
     #[test]
     fn test_scroll_bounds_with_new_layout() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let mut result = create_test_result();
         // Create a message with exactly 10 lines
         result.text = (0..10)
@@ -501,7 +501,7 @@ mod tests {
 
     #[test]
     fn test_header_always_visible() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let mut result = create_test_result();
         // Create a very long message
         result.text = (0..100)
@@ -538,7 +538,7 @@ mod tests {
 
     #[test]
     fn test_empty_message_scrolling() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let mut result = create_test_result();
         result.text = "".to_string(); // Empty message
         detail.set_result(result);
@@ -563,7 +563,7 @@ mod tests {
 
     #[test]
     fn test_message_title_shows_scroll_position() {
-        let mut detail = ResultDetail::new();
+        let mut detail = MessageDetail::new();
         let mut result = create_test_result();
         // Create a message with 20 lines
         result.text = (0..20)

--- a/src/interactive_ratatui/ui/components/mod.rs
+++ b/src/interactive_ratatui/ui/components/mod.rs
@@ -1,7 +1,7 @@
 pub mod help_dialog;
 pub mod list_item;
 pub mod list_viewer;
-pub mod result_detail;
+pub mod message_detail;
 pub mod result_list;
 pub mod search_bar;
 pub mod session_viewer;
@@ -13,7 +13,7 @@ mod list_item_test;
 #[cfg(test)]
 mod list_viewer_test;
 #[cfg(test)]
-mod result_detail_test;
+mod message_detail_test;
 #[cfg(test)]
 mod result_list_test;
 #[cfg(test)]

--- a/src/interactive_ratatui/ui/components/result_list.rs
+++ b/src/interactive_ratatui/ui/components/result_list.rs
@@ -163,7 +163,7 @@ impl Component for ResultList {
                     None
                 }
             }
-            KeyCode::Enter => Some(Message::EnterResultDetail),
+            KeyCode::Enter => Some(Message::EnterMessageDetail),
             KeyCode::Char('s') if key.modifiers == KeyModifiers::CONTROL => {
                 Some(Message::EnterSessionViewer) // Ctrl+S
             }

--- a/src/interactive_ratatui/ui/components/result_list_test.rs
+++ b/src/interactive_ratatui/ui/components/result_list_test.rs
@@ -138,7 +138,7 @@ mod tests {
 
         // Enter should open detail view
         let msg = list.handle_key(create_key_event(KeyCode::Enter));
-        assert!(matches!(msg, Some(Message::EnterResultDetail)));
+        assert!(matches!(msg, Some(Message::EnterMessageDetail)));
     }
 
     #[test]

--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -501,7 +501,7 @@ impl Component for SessionViewer {
                     .map(|path| Message::CopyToClipboard(CopyContent::FilePath(path))),
                 KeyCode::Enter => self.list_viewer.get_selected_item().and_then(|item| {
                     self.file_path.as_ref().map(|path| {
-                        Message::EnterResultDetailFromSession(
+                        Message::EnterMessageDetailFromSession(
                             item.raw_json.clone(),
                             path.clone(),
                             self.session_id.clone(),

--- a/src/interactive_ratatui/ui/events.rs
+++ b/src/interactive_ratatui/ui/events.rs
@@ -7,7 +7,7 @@ pub enum CopyContent {
     SessionId(String),
     MessageContent(String),
     JsonData(String),
-    FullResultDetails(String),
+    FullMessageDetails(String),
 }
 
 #[derive(Clone, Debug)]
@@ -22,9 +22,9 @@ pub enum Message {
     ToggleSearchOrder,
 
     // Mode changes
-    EnterResultDetail,
+    EnterMessageDetail,
     EnterSessionViewer,
-    EnterResultDetailFromSession(String, String, Option<String>), // (raw_json, file_path, session_id)
+    EnterMessageDetailFromSession(String, String, Option<String>), // (raw_json, file_path, session_id)
     ExitToSearch,
     ShowHelp,
     CloseHelp,

--- a/src/interactive_ratatui/ui/navigation.rs
+++ b/src/interactive_ratatui/ui/navigation.rs
@@ -228,7 +228,7 @@ mod tests {
         assert!(!history.can_go_forward());
 
         // Push second state
-        let state2 = create_test_state(Mode::ResultDetail);
+        let state2 = create_test_state(Mode::MessageDetail);
         history.push(state2.clone());
         assert_eq!(history.len(), 2);
         assert!(history.can_go_back()); // Can go back
@@ -240,7 +240,7 @@ mod tests {
         let mut history = NavigationHistory::new(10);
 
         let state1 = create_test_state(Mode::Search);
-        let state2 = create_test_state(Mode::ResultDetail);
+        let state2 = create_test_state(Mode::MessageDetail);
         let state3 = create_test_state(Mode::SessionViewer);
 
         history.push(state1.clone());
@@ -251,7 +251,7 @@ mod tests {
         // Go back - should return ResultDetail and move to index 1
         assert!(history.can_go_back());
         let back_state = history.go_back().unwrap();
-        assert_eq!(back_state.mode, Mode::ResultDetail);
+        assert_eq!(back_state.mode, Mode::MessageDetail);
         assert!(history.can_go_back());
         assert!(history.can_go_forward());
 
@@ -266,7 +266,7 @@ mod tests {
 
         // Go forward - should return ResultDetail and move to index 1
         let forward_state = history.go_forward().unwrap();
-        assert_eq!(forward_state.mode, Mode::ResultDetail);
+        assert_eq!(forward_state.mode, Mode::MessageDetail);
         assert!(history.can_go_back());
         assert!(history.can_go_forward());
 
@@ -282,7 +282,7 @@ mod tests {
         let mut history = NavigationHistory::new(10);
 
         let state1 = create_test_state(Mode::Search);
-        let state2 = create_test_state(Mode::ResultDetail);
+        let state2 = create_test_state(Mode::MessageDetail);
         let state3 = create_test_state(Mode::SessionViewer);
         let state4 = create_test_state(Mode::Help);
 

--- a/src/interactive_ratatui/ui/renderer.rs
+++ b/src/interactive_ratatui/ui/renderer.rs
@@ -1,7 +1,7 @@
 use crate::interactive_ratatui::constants::*;
 use crate::interactive_ratatui::ui::app_state::{AppState, Mode};
 use crate::interactive_ratatui::ui::components::{
-    Component, help_dialog::HelpDialog, is_exit_prompt, result_detail::ResultDetail,
+    Component, help_dialog::HelpDialog, is_exit_prompt, message_detail::MessageDetail,
     result_list::ResultList, search_bar::SearchBar, session_viewer::SessionViewer,
 };
 use ratatui::{
@@ -15,7 +15,7 @@ use ratatui::{
 pub struct Renderer {
     search_bar: SearchBar,
     result_list: ResultList,
-    result_detail: ResultDetail,
+    message_detail: MessageDetail,
     session_viewer: SessionViewer,
     help_dialog: HelpDialog,
 }
@@ -25,7 +25,7 @@ impl Renderer {
         Self {
             search_bar: SearchBar::new(),
             result_list: ResultList::new(),
-            result_detail: ResultDetail::new(),
+            message_detail: MessageDetail::new(),
             session_viewer: SessionViewer::new(),
             help_dialog: HelpDialog::new(),
         }
@@ -34,7 +34,7 @@ impl Renderer {
     pub fn render(&mut self, f: &mut Frame, state: &AppState) {
         match state.mode {
             Mode::Search => self.render_search_mode(f, state),
-            Mode::ResultDetail => self.render_detail_mode(f, state),
+            Mode::MessageDetail => self.render_detail_mode(f, state),
             Mode::SessionViewer => self.render_session_mode(f, state),
             Mode::Help => self.render_help_mode(f, state),
         }
@@ -102,9 +102,9 @@ impl Renderer {
 
     fn render_detail_mode(&mut self, f: &mut Frame, state: &AppState) {
         if let Some(result) = &state.ui.selected_result {
-            self.result_detail.set_result(result.clone());
-            self.result_detail.set_message(state.ui.message.clone());
-            self.result_detail.render(f, f.area());
+            self.message_detail.set_result(result.clone());
+            self.message_detail.set_message(state.ui.message.clone());
+            self.message_detail.render(f, f.area());
         }
     }
 
@@ -150,8 +150,8 @@ impl Renderer {
         &mut self.result_list
     }
 
-    pub fn get_result_detail_mut(&mut self) -> &mut ResultDetail {
-        &mut self.result_detail
+    pub fn get_message_detail_mut(&mut self) -> &mut MessageDetail {
+        &mut self.message_detail
     }
 
     pub fn get_session_viewer_mut(&mut self) -> &mut SessionViewer {


### PR DESCRIPTION
## Summary
This PR renames the ResultDetail component to MessageDetail throughout the codebase for better clarity and consistency.

## Changes
- Renamed component files from `result_detail.rs` to `message_detail.rs`
- Updated struct name from `ResultDetail` to `MessageDetail`
- Updated Mode enum variant from `ResultDetail` to `MessageDetail`
- Updated Message enum variants:
  - `EnterResultDetail` → `EnterMessageDetail`
  - `EnterResultDetailFromSession` → `EnterMessageDetailFromSession`
- Updated CopyContent variant from `FullResultDetails` to `FullMessageDetails`
- Updated method name from `get_result_detail_mut()` to `get_message_detail_mut()`
- Updated all imports, field names, and references
- Updated documentation in spec.md, README.md, and CLAUDE.md

## Rationale
The term "Message Detail" better reflects the component's purpose of displaying detailed information about Claude session messages, not just search results. This naming is more accurate and makes the codebase more intuitive.

## Test Plan
- [x] All existing tests pass (265 tests)
- [x] Code compiles without warnings
- [x] No functional changes - this is a pure refactoring