### PR TITLE
refactor: eliminate magic numbers in message_detail.rs layouts

### DIFF
--- a/src/interactive_ratatui/constants.rs
+++ b/src/interactive_ratatui/constants.rs
@@ -47,3 +47,13 @@ pub const MIN_MESSAGE_WIDTH: u16 = 20;
 // Navigation history
 /// Maximum navigation history entries
 pub const MAX_NAVIGATION_HISTORY: usize = 50;
+
+// Message detail layout constants
+/// Height of the details header section (role, time, file, project, UUID, session)
+pub const MESSAGE_DETAIL_HEADER_HEIGHT: u16 = 8;
+
+/// Height of the shortcuts bar in message detail view
+pub const MESSAGE_DETAIL_SHORTCUTS_HEIGHT: u16 = 2;
+
+/// Height of the status bar in message detail view
+pub const MESSAGE_DETAIL_STATUS_HEIGHT: u16 = 1;

--- a/src/interactive_ratatui/ui/components/message_detail.rs
+++ b/src/interactive_ratatui/ui/components/message_detail.rs
@@ -59,7 +59,7 @@ impl MessageDetail {
                 .direction(Direction::Vertical)
                 .constraints([
                     Constraint::Length(MESSAGE_DETAIL_HEADER_HEIGHT), // Header (fixed)
-                    Constraint::Min(5),    // Message content (scrollable)
+                    Constraint::Min(5), // Message content (scrollable)
                     Constraint::Length(MESSAGE_DETAIL_SHORTCUTS_HEIGHT), // Shortcuts (fixed)
                     Constraint::Length(MESSAGE_DETAIL_STATUS_HEIGHT), // Status/Exit prompt at bottom
                 ])
@@ -69,7 +69,7 @@ impl MessageDetail {
                 .direction(Direction::Vertical)
                 .constraints([
                     Constraint::Length(MESSAGE_DETAIL_HEADER_HEIGHT), // Header (fixed)
-                    Constraint::Min(5),    // Message content (scrollable)
+                    Constraint::Min(5), // Message content (scrollable)
                     Constraint::Length(MESSAGE_DETAIL_SHORTCUTS_HEIGHT), // Shortcuts (fixed)
                 ])
                 .split(area)

--- a/src/interactive_ratatui/ui/components/message_detail.rs
+++ b/src/interactive_ratatui/ui/components/message_detail.rs
@@ -1,3 +1,4 @@
+use crate::interactive_ratatui::constants::*;
 use crate::interactive_ratatui::ui::components::{
     Component, is_exit_prompt,
     view_layout::{Styles, ViewLayout},
@@ -57,19 +58,19 @@ impl MessageDetail {
             Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
-                    Constraint::Length(8), // Header (fixed)
+                    Constraint::Length(MESSAGE_DETAIL_HEADER_HEIGHT), // Header (fixed)
                     Constraint::Min(5),    // Message content (scrollable)
-                    Constraint::Length(2), // Shortcuts (fixed)
-                    Constraint::Length(1), // Status/Exit prompt at bottom
+                    Constraint::Length(MESSAGE_DETAIL_SHORTCUTS_HEIGHT), // Shortcuts (fixed)
+                    Constraint::Length(MESSAGE_DETAIL_STATUS_HEIGHT), // Status/Exit prompt at bottom
                 ])
                 .split(area)
         } else {
             Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
-                    Constraint::Length(8), // Header (fixed)
+                    Constraint::Length(MESSAGE_DETAIL_HEADER_HEIGHT), // Header (fixed)
                     Constraint::Min(5),    // Message content (scrollable)
-                    Constraint::Length(2), // Shortcuts (fixed)
+                    Constraint::Length(MESSAGE_DETAIL_SHORTCUTS_HEIGHT), // Shortcuts (fixed)
                 ])
                 .split(area)
         };
@@ -255,27 +256,27 @@ impl Component for MessageDetail {
                 None
             }
             KeyCode::PageUp => {
-                self.scroll_offset = self.scroll_offset.saturating_sub(10);
+                self.scroll_offset = self.scroll_offset.saturating_sub(PAGE_SIZE);
                 None
             }
             KeyCode::PageDown => {
                 // Only scroll if there's content to scroll
                 if let Some(result) = &self.result {
                     if !result.text.is_empty() {
-                        self.scroll_offset += 10;
+                        self.scroll_offset += PAGE_SIZE;
                     }
                 }
                 None
             }
             KeyCode::Char('u') if key.modifiers == KeyModifiers::CONTROL => {
-                self.scroll_offset = self.scroll_offset.saturating_sub(10);
+                self.scroll_offset = self.scroll_offset.saturating_sub(PAGE_SIZE);
                 None
             }
             KeyCode::Char('d') if key.modifiers == KeyModifiers::CONTROL => {
                 // Only scroll if there's content to scroll
                 if let Some(result) = &self.result {
                     if !result.text.is_empty() {
-                        self.scroll_offset += 10;
+                        self.scroll_offset += PAGE_SIZE;
                     }
                 }
                 None

--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -378,7 +378,7 @@ impl Component for SessionViewer {
                     // Navigate to result detail for selected message
                     self.list_viewer.get_selected_item().and_then(|item| {
                         self.file_path.as_ref().map(|path| {
-                            Message::EnterResultDetailFromSession(
+                            Message::EnterMessageDetailFromSession(
                                 item.raw_json.clone(),
                                 path.clone(),
                                 self.session_id.clone(),


### PR DESCRIPTION
## Summary
- Replaces hardcoded layout constraint values with named constants in `message_detail.rs`
- Adds new constants to `constants.rs` for better maintainability
- Also includes a minor naming fix for `EnterMessageDetailFromSession`

## Changes
1. **Added constants to `constants.rs`**:
   - `MESSAGE_DETAIL_HEADER_HEIGHT` (8) - Height of the details header section
   - `MESSAGE_DETAIL_SHORTCUTS_HEIGHT` (2) - Height of the shortcuts bar 
   - `MESSAGE_DETAIL_STATUS_HEIGHT` (1) - Height of the status bar

2. **Updated `message_detail.rs`**:
   - Replaced hardcoded layout constraint values with the new constants
   - Replaced hardcoded page scroll value (10) with existing `PAGE_SIZE` constant
   - Improves code readability and maintainability

3. **Fixed naming in `session_viewer.rs`**:
   - Updated `EnterResultDetailFromSession` to `EnterMessageDetailFromSession` to match recent naming changes

## Motivation
Part of the ongoing Layout API improvements initiative to eliminate magic numbers and improve code maintainability throughout the interactive TUI.

## Test plan
- [x] All existing tests pass
- [x] Manual testing shows no functional changes
- [x] Code compiles without warnings
- [x] Message detail view displays correctly with proper layout