### PR TITLE
fix: rename EnterResultDetailFromSession to EnterMessageDetailFromSession

### DIFF
--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -378,7 +378,7 @@ impl Component for SessionViewer {
                     // Navigate to result detail for selected message
                     self.list_viewer.get_selected_item().and_then(|item| {
                         self.file_path.as_ref().map(|path| {
-                            Message::EnterResultDetailFromSession(
+                            Message::EnterMessageDetailFromSession(
                                 item.raw_json.clone(),
                                 path.clone(),
                                 self.session_id.clone(),


### PR DESCRIPTION
## Summary
This PR fixes a build error caused by using an incorrect enum variant name.

## Changes
- Renamed `EnterResultDetailFromSession` to `EnterMessageDetailFromSession` in `session_viewer.rs`
- This matches the actual variant defined in the `Message` enum in `events.rs`

## Context
The build was failing with:
```
error[E0599]: no variant or associated item named `EnterResultDetailFromSession` found for enum `Message`
```

This was a simple naming mismatch that needed to be corrected.

## Test Plan
- [x] Build passes with `cargo build --release`
- [x] All tests pass with `cargo test`
- [x] Clippy passes with `cargo clippy --all-targets --all-features -- -D warnings`