### PR TITLE
refactor: replace hardcoded exit prompt height with constant in renderer

### DIFF
--- a/src/interactive_ratatui/constants.rs
+++ b/src/interactive_ratatui/constants.rs
@@ -57,3 +57,7 @@ pub const MESSAGE_DETAIL_SHORTCUTS_HEIGHT: u16 = 2;
 
 /// Height of the status bar in message detail view
 pub const MESSAGE_DETAIL_STATUS_HEIGHT: u16 = 1;
+
+// General UI layout constants
+/// Height of the exit prompt displayed at the bottom
+pub const EXIT_PROMPT_HEIGHT: u16 = 1;

--- a/src/interactive_ratatui/ui/renderer.rs
+++ b/src/interactive_ratatui/ui/renderer.rs
@@ -48,9 +48,9 @@ impl Renderer {
             Layout::default()
                 .direction(Direction::Vertical)
                 .constraints([
-                    Constraint::Length(SEARCH_BAR_HEIGHT), // Search bar
-                    Constraint::Min(0),                    // Results
-                    Constraint::Length(1),                 // Exit prompt
+                    Constraint::Length(SEARCH_BAR_HEIGHT),  // Search bar
+                    Constraint::Min(0),                     // Results
+                    Constraint::Length(EXIT_PROMPT_HEIGHT), // Exit prompt
                 ])
                 .split(f.area())
         } else {


### PR DESCRIPTION
## Summary
- Adds `EXIT_PROMPT_HEIGHT` constant to centralize layout configuration
- Replaces hardcoded value in `renderer.rs` for better maintainability

## Changes
1. **Added constant to `constants.rs`**:
   - `EXIT_PROMPT_HEIGHT` (1) - Height of the exit prompt displayed at the bottom

2. **Updated `renderer.rs`**:
   - Replaced hardcoded layout constraint value `1` with `EXIT_PROMPT_HEIGHT` constant
   - Improves code readability and makes it easier to adjust layout dimensions

## Motivation
Part of the ongoing Layout API improvements initiative to eliminate magic numbers and improve code maintainability throughout the interactive TUI.

## Test plan
- [x] All existing tests pass
- [x] Manual testing shows no functional changes
- [x] Code compiles without warnings
- [x] Exit prompt displays correctly when triggered