### PR TITLE
refactor: eliminate remaining magic numbers across UI components

### DIFF
--- a/src/interactive_ratatui/constants.rs
+++ b/src/interactive_ratatui/constants.rs
@@ -61,3 +61,33 @@ pub const MESSAGE_DETAIL_STATUS_HEIGHT: u16 = 1;
 // General UI layout constants
 /// Height of the exit prompt displayed at the bottom
 pub const EXIT_PROMPT_HEIGHT: u16 = 1;
+
+// Result list layout constants
+/// Height of the title area in result list
+pub const RESULT_LIST_TITLE_HEIGHT: u16 = 2;
+
+/// Height of the status bar in result list
+pub const RESULT_LIST_STATUS_HEIGHT: u16 = 2;
+
+// List viewer default values
+/// Default viewport height for list viewer
+pub const DEFAULT_VIEWPORT_HEIGHT: u16 = 10;
+
+/// Estimated viewport size for truncated mode
+pub const TRUNCATED_VIEWPORT_ESTIMATE: usize = 20;
+
+/// Estimated viewport size for full text mode
+pub const FULL_TEXT_VIEWPORT_ESTIMATE: usize = 10;
+
+// View layout border and sizing constants
+/// Width adjustment for borders (left and right)
+pub const BORDER_WIDTH_ADJUSTMENT: u16 = 2;
+
+/// Height adjustment for bottom border
+pub const BORDER_HEIGHT_ADJUSTMENT: u16 = 1;
+
+/// Minimum height for status bar
+pub const STATUS_BAR_MIN_HEIGHT: u16 = 1;
+
+/// Maximum height for status bar
+pub const STATUS_BAR_MAX_HEIGHT: u16 = 3;

--- a/src/interactive_ratatui/ui/components/list_viewer.rs
+++ b/src/interactive_ratatui/ui/components/list_viewer.rs
@@ -30,7 +30,7 @@ impl<T: ListItem> Default for ListViewer<T> {
             title: String::new(),
             empty_message: String::new(),
             query: String::new(),
-            last_viewport_height: 10,
+            last_viewport_height: DEFAULT_VIEWPORT_HEIGHT,
         }
     }
 }
@@ -42,10 +42,10 @@ impl<T: ListItem> ListViewer<T> {
         let position = self.selected_index;
         let viewport_size = if self.truncation_enabled {
             // Estimate based on typical terminal height
-            20
+            TRUNCATED_VIEWPORT_ESTIMATE
         } else {
             // In full text mode, harder to estimate
-            10
+            FULL_TEXT_VIEWPORT_ESTIMATE
         };
         (position, viewport_size, total)
     }
@@ -59,7 +59,7 @@ impl<T: ListItem> ListViewer<T> {
             title,
             empty_message,
             query: String::new(),
-            last_viewport_height: 10,
+            last_viewport_height: DEFAULT_VIEWPORT_HEIGHT,
         }
     }
 

--- a/src/interactive_ratatui/ui/components/result_list.rs
+++ b/src/interactive_ratatui/ui/components/result_list.rs
@@ -1,3 +1,4 @@
+use crate::interactive_ratatui::constants::*;
 use crate::interactive_ratatui::ui::components::{
     Component, list_viewer::ListViewer, view_layout::Styles,
 };
@@ -65,9 +66,9 @@ impl Component for ResultList {
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(2), // Title
-                Constraint::Min(0),    // Content (list)
-                Constraint::Length(2), // Status
+                Constraint::Length(RESULT_LIST_TITLE_HEIGHT),  // Title
+                Constraint::Min(0),                            // Content (list)
+                Constraint::Length(RESULT_LIST_STATUS_HEIGHT), // Status
             ])
             .split(area);
 

--- a/src/interactive_ratatui/ui/components/view_layout.rs
+++ b/src/interactive_ratatui/ui/components/view_layout.rs
@@ -1,3 +1,4 @@
+use crate::interactive_ratatui::constants::*;
 use ratatui::{
     Frame,
     layout::{Constraint, Direction, Layout, Rect},
@@ -59,10 +60,11 @@ impl ViewLayout {
         let paragraph = Paragraph::new(lines).wrap(Wrap { trim: true });
 
         // Use ratatui's line_count method to get the actual height needed
-        let content_height = paragraph.line_count(width.saturating_sub(2)) as u16;
+        let content_height =
+            paragraph.line_count(width.saturating_sub(BORDER_WIDTH_ADJUSTMENT)) as u16;
 
         // Add 1 for the bottom border
-        content_height + 1
+        content_height + BORDER_HEIGHT_ADJUSTMENT
     }
 
     fn calculate_status_bar_height(&self, width: u16) -> u16 {
@@ -78,7 +80,7 @@ impl ViewLayout {
         let content_height = paragraph.line_count(width) as u16;
 
         // Ensure at least 1 line, max 3 lines for status bar
-        content_height.clamp(1, 3)
+        content_height.clamp(STATUS_BAR_MIN_HEIGHT, STATUS_BAR_MAX_HEIGHT)
     }
 
     pub fn render<F>(&self, f: &mut Frame, area: Rect, render_content: F)


### PR DESCRIPTION
## Summary
This PR completes the Layout API improvements initiative by eliminating all remaining magic numbers across the interactive TUI components. It adds comprehensive constants for all hardcoded values found during the code audit.

## Changes

### 1. Added new constants to `constants.rs`:

**Result list layout constants**:
- `RESULT_LIST_TITLE_HEIGHT` (2) - Height of the title area in result list
- `RESULT_LIST_STATUS_HEIGHT` (2) - Height of the status bar in result list

**List viewer default values**:
- `DEFAULT_VIEWPORT_HEIGHT` (10) - Default viewport height for list viewer
- `TRUNCATED_VIEWPORT_ESTIMATE` (20) - Estimated viewport size for truncated mode
- `FULL_TEXT_VIEWPORT_ESTIMATE` (10) - Estimated viewport size for full text mode

**View layout border and sizing constants**:
- `BORDER_WIDTH_ADJUSTMENT` (2) - Width adjustment for borders (left and right)
- `BORDER_HEIGHT_ADJUSTMENT` (1) - Height adjustment for bottom border
- `STATUS_BAR_MIN_HEIGHT` (1) - Minimum height for status bar
- `STATUS_BAR_MAX_HEIGHT` (3) - Maximum height for status bar

### 2. Updated components:

**`result_list.rs`**:
- Replaced hardcoded layout constraint values `2` with named constants
- Added import for constants module

**`list_viewer.rs`**:
- Replaced default viewport height `10` with `DEFAULT_VIEWPORT_HEIGHT`
- Replaced viewport size estimates `20` and `10` with named constants

**`view_layout.rs`**:
- Replaced border width adjustment `2` with `BORDER_WIDTH_ADJUSTMENT`
- Replaced border height adjustment `1` with `BORDER_HEIGHT_ADJUSTMENT`
- Replaced status bar height limits `1` and `3` with named constants
- Added import for constants module

## Motivation
This completes the Layout API improvements initiative by ensuring all magic numbers in the UI components are replaced with self-documenting constants. This improves code maintainability and makes it easier to adjust layout parameters across the entire application.

## Test plan
- [x] All existing tests pass (343 tests)
- [x] Manual testing shows no visual or functional changes
- [x] Code compiles without warnings
- [x] Layout calculations remain identical to previous behavior