### PR TITLE
Fix project path filtering in interactive mode

### DIFF
--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -282,9 +282,16 @@ impl SearchEngine {
 
                             // Check project path filter
                             if let Some(project_filter) = &self.options.project_path {
-                                let project_path = Self::extract_project_path(file_path);
-                                if !project_path.starts_with(project_filter) {
-                                    continue;
+                                // Instead of decoding the project path, encode the filter and compare
+                                let encoded_filter = Self::encode_project_path(project_filter);
+                                if let Some(parent) = file_path.parent() {
+                                    if let Some(project_name) = parent.file_name() {
+                                        if let Some(project_str) = project_name.to_str() {
+                                            if !project_str.starts_with(&encoded_filter) {
+                                                continue;
+                                            }
+                                        }
+                                    }
                                 }
                             }
 
@@ -412,6 +419,15 @@ impl SearchEngine {
             }
         }
         String::new()
+    }
+
+    fn encode_project_path(path: &str) -> String {
+        // Encode project path for comparison with Claude's encoding
+        // Claude's encoding replaces these characters with hyphens:
+        // - Path separators (/)
+        // - Dots (.)
+        // - Underscores (_)
+        path.replace(['/', '.', '_'], "-")
     }
 }
 


### PR DESCRIPTION
## Summary

This PR fixes a critical bug in the `--project` path filtering feature where it wasn't working correctly in interactive mode (and was also broken in non-interactive mode).

## Problem

The issue was with how Claude encodes project paths in its directory structure. Claude replaces not just forward slashes (`/`) but also dots (`.`) and underscores (`_`) with hyphens (`-`) when creating project directories.

For example:
- Actual path: `/Users/masatomokusaka/src/github.com/mkusaka/ccms/.git/tmp_worktrees/20250801_040946_proj-with-interactive`
- Claude's encoded directory: `-Users-masatomokusaka-src-github-com-mkusaka-ccms--git-tmp-worktrees-20250801-040946-proj-with-interactive`

## Solution

Instead of decoding Claude's directory names and comparing with the user's filter, we now:
1. Encode the user's filter path using the same encoding rules Claude uses
2. Compare the encoded filter with Claude's encoded directory names directly

This ensures that `ccms --project $(pwd) -i` correctly filters messages to only show those from the specified project path.

## Changes

- Added `encode_project_path()` function that replicates Claude's encoding logic
- Updated the project path filtering logic to use encoded comparison
- Fixed the implementation to handle dots and underscores in addition to slashes

## Testing

- All existing tests pass
- Manually tested with various project paths including git worktrees
- No clippy warnings