### PR TITLE
Make query argument optional and auto-start interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ After installation, restart your shell or source your configuration file to enab
 ### Basic Search
 
 ```bash
+# Launch interactive mode (no arguments needed)
+ccms
+
 # Search for "error" in all Claude sessions
 ccms "error"
 
@@ -111,10 +114,13 @@ ccms --project "$(pwd)" "TODO"
 
 ### Interactive Mode (TUI)
 
-Launch an interactive search interface similar to fzf. All filtering options work in interactive mode:
+Launch an interactive search interface similar to fzf. Interactive mode starts automatically when no query is provided:
 
 ```bash
-# Interactive search in default location
+# Interactive search (default when no query provided)
+ccms
+
+# Explicit interactive mode
 ccms -i
 
 # Interactive search in specific directory
@@ -269,6 +275,7 @@ ccms -v "query"
 
 ### Interactive Mode
 - `-i, --interactive` - Launch interactive search mode (fzf-like TUI)
+- **Note**: Interactive mode starts automatically when no query is provided
 
 ### Other Options
 - `--help-query` - Show query syntax help

--- a/spec.md
+++ b/spec.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-The interactive mode provides a terminal-based user interface for searching Claude session messages in real-time. It uses the `ratatui` crate with crossterm backend for terminal control and implements features like incremental search, result navigation, role filtering, and clipboard operations.
+The interactive mode provides a terminal-based user interface for searching Claude session messages in real-time. Interactive mode starts automatically when `ccms` is run without a query argument. It uses the `ratatui` crate with crossterm backend for terminal control and implements features like incremental search, result navigation, role filtering, and clipboard operations.
+
+**Automatic Launch**: Running `ccms` without any arguments will start interactive mode by default.
 
 ## User Interface Layout
 
@@ -10,7 +12,7 @@ The interactive mode provides a terminal-based user interface for searching Clau
 
 ```
 Interactive Claude Search
-Type to search, ↑/↓ to navigate, Enter to select, Tab for role filter, Ctrl+R to reload, Esc/Ctrl+C to exit
+Type to search, ↑/↓ to navigate, Enter to select, Tab for role filter, Ctrl+R to reload, Ctrl+C (2x) to exit
 
 Search: [cursor]
 ```
@@ -21,7 +23,7 @@ When a query is entered, the interface shows:
 
 ```
 Interactive Claude Search
-Type to search, ↑/↓ to navigate, Enter to select, Tab for role filter, Ctrl+R to reload, Esc/Ctrl+C to exit
+Type to search, ↑/↓ to navigate, Enter to select, Tab for role filter, Ctrl+R to reload, Ctrl+C (2x) to exit
 
 Search: [query]
 Found N results (limit reached if applicable)
@@ -373,7 +375,7 @@ Note: The Message Detail view always displays messages with word wrapping and is
 
 ## Exit Behavior
 
-On exit (Ctrl+C pressed twice within 1 second from Search screen, or 'q' key):
+On exit (Ctrl+C pressed twice within 1 second from Search screen):
 1. Clears search area from screen
 2. Displays "Goodbye!" message
 3. Returns control to terminal

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,6 @@ use std::io::{self, Write};
 )]
 struct Cli {
     /// Search query (supports literal, regex, AND/OR/NOT operators)
-    #[arg(required_unless_present_any = ["interactive", "generator"])]
     query: Option<String>,
 
     /// File pattern to search (default: ~/.claude/projects/**/*.jsonl)
@@ -162,8 +161,8 @@ fn main() -> Result<()> {
     let default_pattern = default_claude_pattern();
     let pattern = cli.pattern.as_deref().unwrap_or(&default_pattern);
 
-    // Interactive mode
-    if cli.interactive {
+    // Interactive mode or no query provided
+    if cli.interactive || cli.query.is_none() {
         let options = SearchOptions {
             max_results: Some(cli.max_results), // Use the CLI value directly
             role: cli.role,
@@ -178,10 +177,8 @@ fn main() -> Result<()> {
         return interactive.run(pattern);
     }
 
-    // Regular search mode - query is required
-    let query_str = cli.query.ok_or_else(|| {
-        anyhow::anyhow!("Query argument is required (use --interactive for interactive mode)")
-    })?;
+    // Regular search mode - query is provided
+    let query_str = cli.query.unwrap();
 
     // Parse the query
     let query = match parse_query(&query_str) {


### PR DESCRIPTION
## Summary
This PR makes the query argument optional and automatically launches interactive mode when no query is provided, improving user experience by providing a more intuitive default behavior.

## Changes
- Removed `required_unless_present_any` constraint from the query argument in CLI parser
- Modified main logic to automatically start interactive mode when no query is provided
- Updated README.md to document the new default behavior
- Updated spec.md to reflect that interactive mode starts automatically without arguments

## Behavior
### Before
```bash
# Would show error: "Query argument is required"
ccms

# Required explicit flag for interactive mode
ccms -i
```

### After
```bash
# Automatically starts interactive mode
ccms

# Still works with query for non-interactive search
ccms "search term"

# Explicit interactive mode still supported
ccms -i
```

## Testing
- Tested that `ccms` without arguments launches interactive mode
- Verified that search with query argument still works as expected
- Confirmed that explicit `-i` flag continues to work
- All existing functionality remains intact

This change provides a more user-friendly experience by defaulting to the interactive mode when users run the command without arguments, similar to tools like `fzf`.