### PR TITLE
feat: display timestamps in local timezone

### DIFF
--- a/src/interactive_ratatui/session_view_integration_test.rs
+++ b/src/interactive_ratatui/session_view_integration_test.rs
@@ -150,7 +150,16 @@ mod tests {
             content.contains("assistant"),
             "Should display assistant role"
         );
-        assert!(content.contains("01/01 12:00"), "Should display timestamp");
+        // Check that timestamp is displayed (will be in local timezone)
+        // The timestamp "2024-01-01T12:00:00Z" will be converted to local time
+        use chrono::{DateTime, Local, TimeZone};
+        let utc_dt = DateTime::parse_from_rfc3339("2024-01-01T12:00:00Z").unwrap();
+        let local_dt = Local.from_utc_datetime(&utc_dt.naive_utc());
+        let expected_time = local_dt.format("%m/%d %H:%M").to_string();
+        assert!(
+            content.contains(&expected_time),
+            "Should display timestamp in local timezone"
+        );
         // Japanese characters might be displayed with space separation in terminal UI
         assert!(
             content.contains("こ")

--- a/src/interactive_ratatui/ui/components/list_item.rs
+++ b/src/interactive_ratatui/ui/components/list_item.rs
@@ -29,7 +29,10 @@ pub trait ListItem: Clone {
     fn format_timestamp(&self) -> String {
         let timestamp = self.get_timestamp();
         if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(timestamp) {
-            dt.format("%m/%d %H:%M").to_string()
+            // Convert to local timezone
+            use chrono::{Local, TimeZone};
+            let local_dt = Local.from_utc_datetime(&dt.naive_utc());
+            local_dt.format("%m/%d %H:%M").to_string()
         } else if timestamp.len() >= 16 {
             timestamp.chars().take(16).collect()
         } else {

--- a/src/interactive_ratatui/ui/components/message_detail.rs
+++ b/src/interactive_ratatui/ui/components/message_detail.rs
@@ -77,7 +77,10 @@ impl MessageDetail {
 
         // Format timestamp
         let timestamp = if let Ok(dt) = chrono::DateTime::parse_from_rfc3339(&result.timestamp) {
-            dt.format("%Y-%m-%d %H:%M:%S %Z").to_string()
+            // Convert to local timezone
+            use chrono::{Local, TimeZone};
+            let local_dt = Local.from_utc_datetime(&dt.naive_utc());
+            local_dt.format("%Y-%m-%d %H:%M:%S %Z").to_string()
         } else {
             result.timestamp.clone()
         };

--- a/src/interactive_ratatui/ui/components/session_viewer_test.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer_test.rs
@@ -380,7 +380,12 @@ mod tests {
         // Should display parsed messages with role and time
         // Note: The new ListViewer displays role without brackets and padded to 10 chars
         assert!(buffer_contains(&buffer, "user"));
-        assert!(buffer_contains(&buffer, "01/01 12:00"));
+        // Check that timestamp is displayed (will be in local timezone)
+        use chrono::{DateTime, Local, TimeZone};
+        let utc_dt = DateTime::parse_from_rfc3339("2024-01-01T12:00:00Z").unwrap();
+        let local_dt = Local.from_utc_datetime(&utc_dt.naive_utc());
+        let expected_time = local_dt.format("%m/%d %H:%M").to_string();
+        assert!(buffer_contains(&buffer, &expected_time));
         assert!(buffer_contains(&buffer, "Hello world"));
         assert!(buffer_contains(&buffer, "assistant"));
         assert!(buffer_contains(&buffer, "Hi there!"));

--- a/src/search/engine.rs
+++ b/src/search/engine.rs
@@ -475,10 +475,13 @@ fn format_preview(text: &str, query: &QueryCondition, context_length: usize) -> 
 }
 
 pub fn format_search_result(result: &SearchResult, use_color: bool, full_text: bool) -> String {
+    use chrono::{Local, TimeZone};
     use colored::Colorize;
 
     let timestamp = if let Ok(dt) = DateTime::parse_from_rfc3339(&result.timestamp) {
-        dt.format("%Y-%m-%d %H:%M:%S").to_string()
+        // Convert to local timezone
+        let local_dt = Local.from_utc_datetime(&dt.naive_utc());
+        local_dt.format("%Y-%m-%d %H:%M:%S").to_string()
     } else {
         result.timestamp.clone()
     };


### PR DESCRIPTION
## Summary
- Display all timestamps in the user's local timezone instead of UTC
- Improves user experience by showing times in a familiar format
- Maintains UTC storage format for consistency

## Changes
- Updated `format_timestamp()` in `list_item.rs` to convert UTC to local timezone for search results
- Modified `format_search_result()` in `engine.rs` to display local timezone in CLI output
- Updated timestamp formatting in `message_detail.rs` to show local timezone with timezone abbreviation
- Fixed tests to validate timezone conversion dynamically based on system timezone

## Test plan
- [x] All existing tests pass with timezone conversion
- [x] Manual testing shows correct local timezone display
- [x] No clippy warnings introduced

## Example
Before (UTC):
```
2024-01-01 12:30:45 assistant [file.jsonl] uuid-123
```

After (Local timezone, e.g., JST):
```
2024-01-01 21:30:45 assistant [file.jsonl] uuid-123
```

🤖 Generated with [Claude Code](https://claude.ai/code)