### PR TITLE
feat: unify loading indicators and fix Tab role change indicator

### DIFF
--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -93,12 +93,12 @@ impl AppState {
         match msg {
             Message::QueryChanged(q) => {
                 self.search.query = q;
-                self.ui.message = Some("typing...".to_string());
+                self.ui.message = Some("[typing...]".to_string());
                 Command::ScheduleSearch(300) // 300ms debounce
             }
             Message::SearchRequested => {
                 self.search.is_searching = true;
-                self.ui.message = Some("searching...".to_string());
+                self.ui.message = Some("[searching...]".to_string());
                 self.search.current_search_id += 1;
                 Command::ExecuteSearch
             }
@@ -245,6 +245,10 @@ impl AppState {
                     self.navigation_history
                         .update_current(self.create_navigation_state());
                 }
+                // Set searching state and message
+                self.search.is_searching = true;
+                self.ui.message = Some("[searching...]".to_string());
+                self.search.current_search_id += 1;
                 Command::ExecuteSearch
             }
             Message::ToggleSearchOrder => {
@@ -257,6 +261,10 @@ impl AppState {
                     self.navigation_history
                         .update_current(self.create_navigation_state());
                 }
+                // Set searching state and message
+                self.search.is_searching = true;
+                self.ui.message = Some("[searching...]".to_string());
+                self.search.current_search_id += 1;
                 // Re-execute the search with the new order to get different results
                 Command::ExecuteSearch
             }

--- a/src/interactive_ratatui/ui/app_state_test.rs
+++ b/src/interactive_ratatui/ui/app_state_test.rs
@@ -51,7 +51,7 @@ mod tests {
 
         assert_eq!(state.search.query, "hello world");
         assert!(matches!(command, Command::ScheduleSearch(300)));
-        assert_eq!(state.ui.message, Some("typing...".to_string()));
+        assert_eq!(state.ui.message, Some("[typing...]".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Unified loading indicators to use consistent bracket format
- Fixed missing loading indicator when changing roles with Tab key

## Changes
- Changed `typing...` to `[typing...]` for consistency
- Changed `searching...` to `[searching...]` for consistency  
- Added search state and loading indicator when toggling role filter with Tab
- Added search state and loading indicator when toggling search order
- Updated tests to match new indicator format

## Test plan
- [x] Unit tests pass
- [x] Build succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)