### PR TITLE
fix: handle assistant message content array properly in Message Detail view

### DIFF
--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -385,21 +385,26 @@ impl AppState {
                                 let texts: Vec<String> = arr
                                     .iter()
                                     .filter_map(|item| {
-                                        if let Some(item_type) = item.get("type").and_then(|t| t.as_str()) {
+                                        if let Some(item_type) =
+                                            item.get("type").and_then(|t| t.as_str())
+                                        {
                                             match item_type {
-                                                "text" => item.get("text")
+                                                "text" => item
+                                                    .get("text")
                                                     .and_then(|t| t.as_str())
                                                     .map(|s| s.to_string()),
-                                                "thinking" => item.get("thinking")
+                                                "thinking" => item
+                                                    .get("thinking")
                                                     .and_then(|t| t.as_str())
                                                     .map(|s| s.to_string()),
                                                 "tool_use" => {
-                                                    let name = item.get("name")
+                                                    let name = item
+                                                        .get("name")
                                                         .and_then(|n| n.as_str())
                                                         .unwrap_or("Tool");
                                                     Some(format!("[Tool: {name}]"))
-                                                },
-                                                _ => None
+                                                }
+                                                _ => None,
                                             }
                                         } else {
                                             // Fallback for simple text

--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -385,9 +385,28 @@ impl AppState {
                                 let texts: Vec<String> = arr
                                     .iter()
                                     .filter_map(|item| {
-                                        item.get("text")
-                                            .and_then(|t| t.as_str())
-                                            .map(|s| s.to_string())
+                                        if let Some(item_type) = item.get("type").and_then(|t| t.as_str()) {
+                                            match item_type {
+                                                "text" => item.get("text")
+                                                    .and_then(|t| t.as_str())
+                                                    .map(|s| s.to_string()),
+                                                "thinking" => item.get("thinking")
+                                                    .and_then(|t| t.as_str())
+                                                    .map(|s| s.to_string()),
+                                                "tool_use" => {
+                                                    let name = item.get("name")
+                                                        .and_then(|n| n.as_str())
+                                                        .unwrap_or("Tool");
+                                                    Some(format!("[Tool: {name}]"))
+                                                },
+                                                _ => None
+                                            }
+                                        } else {
+                                            // Fallback for simple text
+                                            item.get("text")
+                                                .and_then(|t| t.as_str())
+                                                .map(|s| s.to_string())
+                                        }
                                     })
                                     .collect();
                                 texts.join(" ")


### PR DESCRIPTION
## Summary
This PR fixes an issue where assistant messages displayed empty content when navigating from Session Viewer to Message Detail view.

## Problem
- Assistant messages have a `content` field that is an array of Content objects, not a simple string
- The existing code only handled the string case, causing empty content display for assistant messages
- This was particularly noticeable when viewing assistant messages from the Session Viewer

## Solution
- Enhanced the content extraction logic to properly handle content arrays
- Check the `type` field of each content item to determine how to extract text:
  - `"text"` type: Extract from the `text` field
  - `"thinking"` type: Extract from the `thinking` field  
  - `"tool_use"` type: Display as `[Tool: {name}]`
- Added fallback handling for content items without a type field
- Join all extracted text with spaces for display

## Changes
- Modified `src/interactive_ratatui/ui/app_state.rs` to handle assistant message content arrays properly
- The fix is specifically in the `EnterMessageDetailFromSession` message handler (lines 380-415)

## Testing
- All 265 existing tests pass
- Manual testing confirms assistant messages now display correctly in Message Detail view
- The fix handles various content types (text, thinking, tool_use) appropriately

## Related Issues
- This improves the user experience when navigating between views in the interactive UI