### PR TITLE
chore: increase default limit from 50 to 200

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ ccms -i -n 100                               # Adjust result limit
 - All command-line filters (`--project`, `--since`, `--after`, `--before`, `-s`, etc.) are applied as base filters
 - The `-r` flag sets the initial role filter, but you can still cycle through roles with Tab
 - Filters persist throughout the interactive session
-- Results are limited by the `-n` flag (default: 50, but 20x more are loaded for scrolling)
+- Results are limited by the `-n` flag (default: 200, but 20x more are loaded for scrolling)
 
 **Result Actions:**
 - `Enter` - View message details
@@ -258,7 +258,7 @@ ccms -v "query"
 
 ### General Options
 - `-p, --pattern <PATTERN>` - File pattern to search (default: `~/.claude/projects/**/*.jsonl`)
-- `-n, --max-results <N>` - Maximum number of results to return (default: 50)
+- `-n, --max-results <N>` - Maximum number of results to return (default: 200)
 - `-f, --format <FORMAT>` - Output format: `text`, `json`, or `jsonl` (default: text)
 - `-v, --verbose` - Enable verbose output
 - `--no-color` - Disable colored output

--- a/spec.md
+++ b/spec.md
@@ -313,7 +313,7 @@ Applied before other filters in the search pipeline.
 
 ### Result Display
 
-- Default max_results: 50 (configurable via CLI)
+- Default max_results: 200 (configurable via CLI)
 - Maximum visible results in list view: dynamically calculated based on terminal height
 - Results list supports scrolling with:
   - ↑/↓: Move selection one item

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ struct Cli {
     session_id: Option<String>,
 
     /// Maximum number of results to return
-    #[arg(short = 'n', long, default_value = "50")]
+    #[arg(short = 'n', long, default_value = "200")]
     max_results: usize,
 
     /// Filter messages before this timestamp (RFC3339 format)


### PR DESCRIPTION
## Summary
- Changed the default value of `-n/--max-results` flag from 50 to 200
- Updated documentation to reflect the new default value

## Changes
- Modified `src/main.rs`: Updated the clap argument default value
- Updated `README.md`: Changed references to the default limit in two places
- Updated `spec.md`: Updated the default max_results specification

## Rationale
Increasing the default limit provides users with more results out of the box, improving the user experience for those who frequently need to see more than 50 results.

## Test plan
- [x] Code compiles successfully
- [x] Help output shows new default value
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)