### PR TITLE
feat: change --project default to current directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,14 @@ ccms -p "~/.claude/projects/myproject/*.jsonl" "bug"
 ccms -r user "how to"
 ccms -r assistant "I can help"
 
-# Filter by current project directory
-ccms --project "$(pwd)" "TODO"
+# Filter by current project directory (default behavior)
+ccms "TODO"                          # Searches in current directory by default
+
+# Explicitly specify project directory
+ccms --project "/path/to/project" "TODO"
+
+# Search all projects (bypass default filter)
+ccms --project "/" "TODO"
 ```
 
 ### Interactive Mode (TUI)
@@ -222,8 +228,11 @@ ccms --since "last week" "weekly review"
 ccms --since "3 days ago" "recent work"
 ccms --since 1720000000 "since Unix timestamp"
 
-# Filter by project path
+# Filter by project path (defaults to current directory if not specified)
 ccms --project "/Users/me/project" "bug"
+
+# Search all projects (bypass default current directory filter)
+ccms --project "/" "bug"
 
 # Combine filters
 ccms -r user -n 20 --after "2024-06-01T00:00:00Z" "question"
@@ -268,7 +277,7 @@ ccms -v "query"
 ### Filtering Options
 - `-r, --role <ROLE>` - Filter by message role: `user`, `assistant`, `system`, or `summary`
 - `-s, --session-id <ID>` - Filter by session ID
-- `--project <PATH>` - Filter by project path (e.g., current directory: `$(pwd)`)
+- `--project <PATH>` - Filter by project path (default: current directory; use `/` to search all projects)
 - `--before <TIMESTAMP>` - Filter messages before this timestamp (RFC3339 format)
 - `--after <TIMESTAMP>` - Filter messages after this timestamp (RFC3339 format)
 - `--since <TIME>` - Filter messages since this time (relative time like "1 day ago" or Unix timestamp)
@@ -346,7 +355,7 @@ cargo build
 # Run tests
 cargo nextest run
 
-# Run clippy
+# Run clippy (checks code quality and style)
 cargo clippy -- -D warnings
 ```
 

--- a/spec.md
+++ b/spec.md
@@ -257,7 +257,10 @@ Applied before other filters in the search pipeline.
 ### Base Options Filters
 
 1. **Session ID**: Filters messages by session_id field
-2. **Timestamp Filters**:
+2. **Project Path**: Filters messages by working directory (cwd) path
+   - Default: Current directory (when not specified)
+   - Use `--project /` to search all projects
+3. **Timestamp Filters**:
    - `before`: RFC3339 timestamp - excludes messages after this time
    - `after`: RFC3339 timestamp - excludes messages before this time
 
@@ -266,9 +269,10 @@ Applied before other filters in the search pipeline.
 1. Query condition evaluation
 2. Role filter (if active)
 3. Session ID filter (if specified)
-4. Timestamp filters (if specified)
-5. Sort by timestamp (newest first)
-6. Limit to max_results
+4. Project path filter (defaults to current directory)
+5. Timestamp filters (if specified)
+6. Sort by timestamp (newest first)
+7. Limit to max_results
 
 ## Search Behavior
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -157,6 +157,13 @@ fn main() -> Result<()> {
         cli.after.clone()
     };
 
+    // Set default project_path to current directory if not specified
+    let project_path = cli.project_path.clone().or_else(|| {
+        std::env::current_dir()
+            .ok()
+            .and_then(|path| path.to_str().map(|s| s.to_string()))
+    });
+
     // Get pattern
     let default_pattern = default_claude_pattern();
     let pattern = cli.pattern.as_deref().unwrap_or(&default_pattern);
@@ -170,7 +177,7 @@ fn main() -> Result<()> {
             before: cli.before,
             after: parsed_after.clone(),
             verbose: cli.verbose,
-            project_path: cli.project_path.clone(),
+            project_path: project_path.clone(),
         };
 
         let mut interactive = InteractiveSearch::new(options);
@@ -198,7 +205,7 @@ fn main() -> Result<()> {
         before: cli.before,
         after: parsed_after,
         verbose: cli.verbose,
-        project_path: cli.project_path,
+        project_path,
     };
 
     if cli.verbose {


### PR DESCRIPTION
## Summary
- Changes the default behavior of the `--project` option to filter by the current working directory
- Previously, when `--project` was not specified, all messages were shown
- Now defaults to showing only messages from the current directory, improving relevance

## Changes
- Modified `main.rs` to set `project_path` to current directory when not specified
- Updated documentation in `README.md` to reflect the new default behavior
- Updated `spec.md` to document the project path filter and its position in the filter chain

## Usage
- Run `ccms` without `--project` to search in the current directory (new default)
- Use `ccms --project /` to search all projects (previous default behavior)
- Use `ccms --project /path/to/project` to search in a specific project

## Test Plan
- [x] All existing tests pass (352 tests)
- [x] Build succeeds with `cargo build --release`
- [x] Manual testing confirms current directory filtering works
- [x] Manual testing confirms `--project /` searches all projects

🤖 Generated with [Claude Code](https://claude.ai/code)