### PR TITLE
perf: change default engine from rayon to smol

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ struct Cli {
     generator: Option<Shell>,
 
     /// Search engine to use
-    #[arg(long, value_enum, default_value = "rayon")]
+    #[arg(long, value_enum, default_value = "smol")]
     engine: EngineType,
 }
 


### PR DESCRIPTION
## Summary
- Changed the default `--engine` value from `rayon` to `smol`

## Why
Based on end-to-end benchmarks, the smol engine shows better performance compared to rayon. This change provides better out-of-the-box performance for users.

Reference: https://github.com/mkusaka/ccms/pull/174#issuecomment-3146721497

## Test plan
- [x] Updated default value in CLI argument definition
- [ ] CI tests will verify functionality
- [ ] No breaking changes - users can still explicitly select rayon with `--engine rayon`

🤖 Generated with [Claude Code](https://claude.ai/code)