### PR TITLE
Remove -i flag and make interactive mode default when no query provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,22 +126,19 @@ Launch an interactive search interface similar to fzf. Interactive mode starts a
 # Interactive search (default when no query provided)
 ccms
 
-# Explicit interactive mode
-ccms -i
-
 # Interactive search in specific directory
-ccms -i -p "~/my-project/*.jsonl"
+ccms -p "~/my-project/*.jsonl"
 
 # Interactive search with filters
-ccms -i --project $(pwd)                    # Current project only
-ccms -i --since "1 day ago"                  # Recent messages only
-ccms -i -r user                              # Pre-filter by role
-ccms -i --project $(pwd) --since "2 hours ago"  # Combine filters
+ccms --project $(pwd)                    # Current project only
+ccms --since "1 day ago"                  # Recent messages only
+ccms -r user                              # Pre-filter by role
+ccms --project $(pwd) --since "2 hours ago"  # Combine filters
 
 # All standard filters are supported
-ccms -i -s "session-id"                      # Filter by session
-ccms -i --after "2024-01-01T00:00:00Z"       # Time range filters
-ccms -i -n 100                               # Adjust result limit
+ccms -s "session-id"                      # Filter by session
+ccms --after "2024-01-01T00:00:00Z"       # Time range filters
+ccms -n 100                               # Adjust result limit
 ```
 
 **Interactive Mode Controls:**

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ use std::io::{self, Write};
     long_about = None
 )]
 struct Cli {
-    /// Search query (supports literal, regex, AND/OR/NOT operators)
+    /// Search query (supports literal, regex, AND/OR/NOT operators). If not provided, enters interactive mode.
     query: Option<String>,
 
     /// File pattern to search (default: ~/.claude/projects/**/*.jsonl)
@@ -77,10 +77,6 @@ struct Cli {
     /// Show raw JSON of matched messages
     #[arg(long)]
     raw: bool,
-
-    /// Interactive search mode (fzf-like)
-    #[arg(short = 'i', long)]
-    interactive: bool,
 
     /// Filter by working directory (cwd) path
     #[arg(long = "project")]
@@ -184,8 +180,8 @@ fn main() -> Result<()> {
     let default_pattern = default_claude_pattern();
     let pattern = cli.pattern.as_deref().unwrap_or(&default_pattern);
 
-    // Interactive mode or no query provided
-    if cli.interactive || cli.query.is_none() {
+    // Interactive mode when no query provided
+    if cli.query.is_none() {
         let options = SearchOptions {
             max_results: Some(cli.max_results), // Use the CLI value directly
             role: cli.role,


### PR DESCRIPTION
## Summary
- Removed the `-i`/`--interactive` flag from the CLI
- Interactive mode now starts automatically when no query is provided
- Updated documentation to reflect this change

## Motivation
This change simplifies the user experience by making the tool more intuitive. Users can now simply run `ccms` without any arguments to enter interactive mode, which is a more natural and expected behavior.

## Changes
1. **CLI Changes**: Removed the `-i`/`--interactive` flag from the CLI struct in `src/main.rs`
2. **Logic Update**: Updated the condition to only check for missing query (removed the `cli.interactive ||` part)
3. **Help Text**: Updated the query parameter help text to indicate that interactive mode is triggered when no query is provided
4. **Documentation**: Updated `README.md` to remove all references to the `-i` flag in examples
5. **Note**: `spec.md` already correctly described the intended behavior, so no changes were needed there

## Test Plan
✅ All existing tests pass
✅ Manual testing confirms:
  - Running `ccms` without arguments enters interactive mode
  - Running `ccms "query"` performs a normal search
  - All other flags work as expected

🤖 Generated with [Claude Code](https://claude.ai/code)