### PR TITLE
refactor: Complete migration from simd-json to sonic-rs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,7 +114,7 @@ The codebase is organized into five main modules:
 ### Key Design Patterns
 
 **Performance Optimizations**:
-- SIMD-accelerated JSON parsing with `simd-json`
+- SIMD-accelerated JSON parsing with `sonic-rs`
 - Parallel file processing using `rayon`
 - Memory-mapped file I/O for large files
 - Early filtering to minimize allocations

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,7 +446,6 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "simd-json",
  "smol",
  "sonic-rs",
  "tempfile",
@@ -1068,15 +1067,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
-name = "float-cmp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1141,11 +1131,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1181,16 +1169,6 @@ checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
-]
-
-[[package]]
-name = "halfbrown"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2c385c6df70fd180bbb673d93039dbd2cd34e41d782600bdf6e1ca7bce39aa"
-dependencies = [
- "hashbrown",
- "serde",
 ]
 
 [[package]]
@@ -2493,21 +2471,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-json"
-version = "0.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c962f626b54771990066e5435ec8331d1462576cd2d1e62f24076ae014f92112"
-dependencies = [
- "getrandom 0.3.3",
- "halfbrown",
- "ref-cast",
- "serde",
- "serde_json",
- "simdutf8",
- "value-trait",
-]
-
-[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3004,18 +2967,6 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
-
-[[package]]
-name = "value-trait"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0508fce11ad19e0aab49ce20b6bec7f8f82902ded31df1c9fc61b90f0eb396b8"
-dependencies = [
- "float-cmp",
- "halfbrown",
- "itoa",
- "ryu",
-]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ clap = { version = "4.5", features = ["derive", "env"] }
 clap_complete = "4.5"
 
 # JSON parsing with SIMD acceleration
-simd-json = "0.15.1"
 sonic-rs = { version = "0.3" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -15,7 +15,7 @@ This document describes the performance optimizations implemented in CCMS.
 - **Impact**: Faster file access for large JSONL files
 
 ### 3. SIMD-Accelerated JSON Parsing
-- **Implementation**: Using `simd-json` for JSON parsing
+- **Implementation**: Using `sonic-rs` for JSON parsing
 - **Impact**: Hardware-accelerated JSON deserialization
 
 ### 4. Parallel File Processing

--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ ccms/
 
 This tool is optimized for maximum performance:
 
-- **SIMD JSON Parsing**: Uses simd-json for hardware-accelerated parsing
+- **SIMD JSON Parsing**: Uses sonic-rs for hardware-accelerated parsing
 - **Parallel Processing**: Leverages all CPU cores with Rayon
 - **Zero-Copy Design**: Minimizes allocations and string copies
 - **Smart Filtering**: Early termination and efficient predicate evaluation
@@ -496,6 +496,6 @@ MIT License - see [LICENSE](LICENSE) file for details
 ## Acknowledgments
 
 - Built with [nom](https://github.com/rust-bakery/nom) for parsing
-- Uses [simd-json](https://github.com/simd-lite/simd-json) for fast JSON parsing
+- Uses [sonic-rs](https://github.com/cloudwego/sonic-rs) for fast JSON parsing
 - Parallel processing powered by [rayon](https://github.com/rayon-rs/rayon)
 - Interactive UI built with [ratatui](https://github.com/ratatui-org/ratatui) and [crossterm](https://github.com/crossterm-rs/crossterm)

--- a/benches/component_benchmark.rs
+++ b/benches/component_benchmark.rs
@@ -59,18 +59,16 @@ fn benchmark_json_parsing(c: &mut Criterion) {
 
     let complex_json = r#"{"type":"assistant","message":{"id":"msg1","type":"message","role":"assistant","model":"claude-3","content":[{"type":"text","text":"Hello world"},{"type":"tool_use","id":"tool1","name":"Bash","input":{"command":"ls -la"}}],"stop_reason":"tool_use","stop_sequence":null,"usage":{"input_tokens":100,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":50}},"uuid":"456","timestamp":"2024-01-01T00:00:01Z","sessionId":"s1","parentUuid":"123","isSidechain":false,"userType":"external","cwd":"/test","version":"1.0","requestId":"req1"}"#;
 
-    group.bench_function("simd_json_simple", |b| {
+    group.bench_function("sonic_rs_simple", |b| {
         b.iter(|| {
-            let mut bytes = simple_json.as_bytes().to_vec();
-            let msg: SessionMessage = simd_json::serde::from_slice(&mut bytes).unwrap();
+            let msg: SessionMessage = sonic_rs::from_slice(simple_json.as_bytes()).unwrap();
             black_box(msg)
         });
     });
 
-    group.bench_function("simd_json_complex", |b| {
+    group.bench_function("sonic_rs_complex", |b| {
         b.iter(|| {
-            let mut bytes = complex_json.as_bytes().to_vec();
-            let msg: SessionMessage = simd_json::serde::from_slice(&mut bytes).unwrap();
+            let msg: SessionMessage = sonic_rs::from_slice(complex_json.as_bytes()).unwrap();
             black_box(msg)
         });
     });

--- a/benches/search_benchmark.rs
+++ b/benches/search_benchmark.rs
@@ -81,8 +81,7 @@ fn benchmark_json_parsing(c: &mut Criterion) {
 
     c.bench_function("json_parse_single", |b| {
         b.iter(|| {
-            let mut bytes = json_line.as_bytes().to_vec();
-            let _: ccms::SessionMessage = simd_json::serde::from_slice(&mut bytes).unwrap();
+            let _: ccms::SessionMessage = sonic_rs::from_slice(json_line.as_bytes()).unwrap();
         });
     });
 }

--- a/src/interactive_ratatui/application/cache_service.rs
+++ b/src/interactive_ratatui/application/cache_service.rs
@@ -41,9 +41,7 @@ impl CacheService {
 
                 raw_lines.push(line.clone());
 
-                let mut json_bytes = line.as_bytes().to_vec();
-                if let Ok(message) = simd_json::serde::from_slice::<SessionMessage>(&mut json_bytes)
-                {
+                if let Ok(message) = sonic_rs::from_slice::<SessionMessage>(line.as_bytes()) {
                     messages.push(message);
                 }
             }


### PR DESCRIPTION
## Summary

This PR completes the migration from `simd-json` to `sonic-rs` for JSON parsing throughout the codebase.

## Motivation

- The codebase was using both `simd-json` and `sonic-rs` for JSON parsing
- `sonic-rs` was already being used in the main search engines (`smol_engine.rs`, `rayon_engine.rs`)
- Having two JSON parsing libraries adds unnecessary dependencies and potential inconsistencies

## Changes

- Replaced `simd_json::serde::from_slice` with `sonic_rs::from_slice` in:
  - `src/interactive_ratatui/application/cache_service.rs`
  - `benches/search_benchmark.rs`
  - `benches/component_benchmark.rs`
- Removed `simd-json` dependency from `Cargo.toml`
- Updated documentation references in README.md, PERFORMANCE.md, and CLAUDE.md

## Technical Details

- `sonic-rs` provides similar SIMD-accelerated JSON parsing performance
- The API migration was straightforward: `sonic_rs::from_slice` accepts immutable byte slices directly, eliminating the need for `to_vec()` calls
- `serde_json` remains for JSON output formatting (pretty printing) and test compatibility, as `sonic-rs` is focused on high-performance parsing

## Testing

- All existing tests pass ✅
- Benchmarks have been updated to use `sonic-rs`
- Release build completed successfully

## Performance Impact

No performance regression expected as both libraries use similar SIMD optimizations for JSON parsing.