### PR TITLE
fix: handle empty string query by entering interactive mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -433,16 +433,29 @@ mod tests {
 
         // Empty string should be detected as empty
         assert!(empty_string.as_ref().map(|s| s.is_empty()).unwrap_or(false));
-        
+
         // Non-empty string should not be detected as empty
-        assert!(!non_empty_string.as_ref().map(|s| s.is_empty()).unwrap_or(false));
-        
+        assert!(
+            !non_empty_string
+                .as_ref()
+                .map(|s| s.is_empty())
+                .unwrap_or(false)
+        );
+
         // None should trigger the first condition (is_none())
         assert!(none_query.is_none());
-        
+
         // The combined condition used in main should be true for both None and empty string
         assert!(none_query.is_none() || none_query.as_ref().map(|s| s.is_empty()).unwrap_or(false));
-        assert!(empty_string.is_none() || empty_string.as_ref().map(|s| s.is_empty()).unwrap_or(false));
-        assert!(!(non_empty_string.is_none() || non_empty_string.as_ref().map(|s| s.is_empty()).unwrap_or(false)));
+        assert!(
+            empty_string.is_none() || empty_string.as_ref().map(|s| s.is_empty()).unwrap_or(false)
+        );
+        assert!(
+            !(non_empty_string.is_none()
+                || non_empty_string
+                    .as_ref()
+                    .map(|s| s.is_empty())
+                    .unwrap_or(false))
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,8 +180,8 @@ fn main() -> Result<()> {
     let default_pattern = default_claude_pattern();
     let pattern = cli.pattern.as_deref().unwrap_or(&default_pattern);
 
-    // Interactive mode when no query provided
-    if cli.query.is_none() {
+    // Interactive mode when no query provided or query is empty
+    if cli.query.is_none() || cli.query.as_ref().map(|s| s.is_empty()).unwrap_or(false) {
         let options = SearchOptions {
             max_results: Some(cli.max_results), // Use the CLI value directly
             role: cli.role,
@@ -422,5 +422,27 @@ mod tests {
         // Test invalid input
         let result = parse_since_time("invalid time");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_empty_query_detection() {
+        // Test that empty string queries are detected correctly
+        let empty_string = Some(String::from(""));
+        let non_empty_string = Some(String::from("test"));
+        let none_query: Option<String> = None;
+
+        // Empty string should be detected as empty
+        assert!(empty_string.as_ref().map(|s| s.is_empty()).unwrap_or(false));
+        
+        // Non-empty string should not be detected as empty
+        assert!(!non_empty_string.as_ref().map(|s| s.is_empty()).unwrap_or(false));
+        
+        // None should trigger the first condition (is_none())
+        assert!(none_query.is_none());
+        
+        // The combined condition used in main should be true for both None and empty string
+        assert!(none_query.is_none() || none_query.as_ref().map(|s| s.is_empty()).unwrap_or(false));
+        assert!(empty_string.is_none() || empty_string.as_ref().map(|s| s.is_empty()).unwrap_or(false));
+        assert!(!(non_empty_string.is_none() || non_empty_string.as_ref().map(|s| s.is_empty()).unwrap_or(false)));
     }
 }


### PR DESCRIPTION
## Summary
This PR fixes an issue where running `ccms ""` with an empty string query would result in a parse error.

## Problem
When users run `ccms ""` (with an empty string as the query), they get:
```
Error parsing query: Parse error: Error(Error { input: "", code: TakeWhile1 })
```

## Solution
Modified the condition in `main.rs` to treat empty string queries the same as no query (None), causing the program to enter interactive mode instead of attempting to parse an empty query.

## Changes
- Updated the condition on line 184 to check for both `None` and empty strings
- Added a test case to verify empty string detection works correctly

## Testing
- All existing tests pass
- Added new test: `test_empty_query_detection`
- Manually verified that both `ccms` and `ccms ""` now enter interactive mode

## Result
Both `ccms` (no query) and `ccms ""` (empty string query) now correctly enter interactive mode without parse errors.