### PR TITLE
refactor: Remove unused has_thinking and has_tools fields

### DIFF
--- a/benches/interactive_ui_benchmark.rs
+++ b/benches/interactive_ui_benchmark.rs
@@ -29,8 +29,6 @@ fn create_test_search_results(count: usize) -> Vec<SearchResult> {
                 session_id: format!("session-{}", i % 10),
                 role: "user".to_string(),
                 text: content,
-                has_tools: false,
-                has_thinking: false,
                 message_type: "user".to_string(),
                 query: QueryCondition::Literal {
                     pattern: "test".to_string(),

--- a/src/interactive_ratatui/domain/filter_test.rs
+++ b/src/interactive_ratatui/domain/filter_test.rs
@@ -11,8 +11,6 @@ mod tests {
             session_id: "test-session".to_string(),
             role: role.to_string(),
             text: text.to_string(),
-            has_tools: false,
-            has_thinking: false,
             message_type: role.to_string(),
             query: QueryCondition::Literal {
                 pattern: "test".to_string(),

--- a/src/interactive_ratatui/domain/models_test.rs
+++ b/src/interactive_ratatui/domain/models_test.rs
@@ -63,8 +63,6 @@ mod tests {
             session_id: "session1".to_string(),
             role: "user".to_string(),
             text: "Hello".to_string(),
-            has_tools: false,
-            has_thinking: false,
             message_type: "user".to_string(),
             query: QueryCondition::Literal {
                 pattern: "test".to_string(),

--- a/src/interactive_ratatui/help_navigation_test.rs
+++ b/src/interactive_ratatui/help_navigation_test.rs
@@ -168,8 +168,6 @@ mod tests {
             session_id: "test-session".to_string(),
             role: "user".to_string(),
             text: "Test content".to_string(),
-            has_tools: false,
-            has_thinking: false,
             message_type: "user".to_string(),
             query: QueryCondition::Literal {
                 pattern: "test".to_string(),

--- a/src/interactive_ratatui/integration_tests.rs
+++ b/src/interactive_ratatui/integration_tests.rs
@@ -137,8 +137,6 @@ mod tests {
             session_id: "87654321-4321-8765-4321-876543218765".to_string(),
             role: "user".to_string(),
             text: "test".to_string(),
-            has_tools: false,
-            has_thinking: false,
             message_type: "user".to_string(),
             query: QueryCondition::Literal {
                 pattern: "test".to_string(),
@@ -237,8 +235,6 @@ mod tests {
             session_id: "87654321-4321-8765-4321-876543218765".to_string(),
             role: role.to_string(),
             text: text.to_string(),
-            has_tools: false,
-            has_thinking: false,
             message_type: role.to_string(),
             query: QueryCondition::Literal {
                 pattern: "test".to_string(),
@@ -1092,8 +1088,6 @@ mod tests {
             session_id: "test-session".to_string(),
             role: "user".to_string(),
             text: "Test message".to_string(),
-            has_tools: false,
-            has_thinking: false,
             message_type: "message".to_string(),
             query: QueryCondition::Literal {
                 pattern: "test".to_string(),

--- a/src/interactive_ratatui/session_view_integration_test.rs
+++ b/src/interactive_ratatui/session_view_integration_test.rs
@@ -104,7 +104,6 @@ mod tests {
         assert_eq!(cached_file.messages[1].get_type(), "system");
         assert_eq!(cached_file.messages[2].get_type(), "user");
         assert_eq!(cached_file.messages[3].get_type(), "assistant");
-
     }
 
     #[test]

--- a/src/interactive_ratatui/session_view_integration_test.rs
+++ b/src/interactive_ratatui/session_view_integration_test.rs
@@ -105,8 +105,6 @@ mod tests {
         assert_eq!(cached_file.messages[2].get_type(), "user");
         assert_eq!(cached_file.messages[3].get_type(), "assistant");
 
-        // Verify assistant message contains thinking
-        assert!(cached_file.messages[3].has_thinking());
     }
 
     #[test]

--- a/src/interactive_ratatui/tests.rs
+++ b/src/interactive_ratatui/tests.rs
@@ -36,8 +36,6 @@ fn test_message_handling() {
         session_id: "test-session".to_string(),
         role: "user".to_string(),
         text: "test text".to_string(),
-        has_tools: false,
-        has_thinking: false,
         message_type: "user".to_string(),
         query: crate::query::condition::QueryCondition::Literal {
             pattern: "test".to_string(),
@@ -65,8 +63,6 @@ fn test_search_filter() {
             session_id: "session1".to_string(),
             role: "user".to_string(),
             text: "user message".to_string(),
-            has_tools: false,
-            has_thinking: false,
             message_type: "user".to_string(),
             query: crate::query::condition::QueryCondition::Literal {
                 pattern: "test".to_string(),
@@ -82,8 +78,6 @@ fn test_search_filter() {
             session_id: "session1".to_string(),
             role: "assistant".to_string(),
             text: "assistant message".to_string(),
-            has_tools: false,
-            has_thinking: false,
             message_type: "assistant".to_string(),
             query: crate::query::condition::QueryCondition::Literal {
                 pattern: "test".to_string(),

--- a/src/interactive_ratatui/ui/app_state.rs
+++ b/src/interactive_ratatui/ui/app_state.rs
@@ -425,8 +425,6 @@ impl AppState {
                         session_id: session_id.unwrap_or_default(),
                         role,
                         text: content, // Store extracted content
-                        has_tools: json_value.get("toolResults").is_some(),
-                        has_thinking: false, // Not available from session viewer
                         message_type: "message".to_string(),
                         query: QueryCondition::Literal {
                             pattern: String::new(),

--- a/src/interactive_ratatui/ui/app_state_test.rs
+++ b/src/interactive_ratatui/ui/app_state_test.rs
@@ -18,8 +18,6 @@ mod tests {
             session_id: "test-session".to_string(),
             role: "user".to_string(),
             text: "Test message".to_string(),
-            has_tools: false,
-            has_thinking: false,
             message_type: "user".to_string(),
             query: QueryCondition::Literal {
                 pattern: "test".to_string(),

--- a/src/interactive_ratatui/ui/components/message_detail_test.rs
+++ b/src/interactive_ratatui/ui/components/message_detail_test.rs
@@ -16,8 +16,6 @@ mod tests {
             timestamp: "2024-01-01T00:00:00Z".to_string(),
             role: "user".to_string(),
             text: "This is a test message".to_string(),
-            has_tools: false,
-            has_thinking: false,
             message_type: "user".to_string(),
             query: QueryCondition::Literal {
                 pattern: String::new(),

--- a/src/interactive_ratatui/ui/components/message_preview_test.rs
+++ b/src/interactive_ratatui/ui/components/message_preview_test.rs
@@ -14,8 +14,6 @@ mod tests {
             session_id: "87654321-4321-8765-4321-876543210987".to_string(),
             role: "user".to_string(),
             text: "This is a test message".to_string(),
-            has_tools: false,
-            has_thinking: false,
             message_type: "message".to_string(),
             query: QueryCondition::Literal {
                 pattern: "test".to_string(),

--- a/src/interactive_ratatui/ui/components/result_list_test.rs
+++ b/src/interactive_ratatui/ui/components/result_list_test.rs
@@ -23,8 +23,6 @@ mod tests {
             session_id: "test-session".to_string(),
             role: role.to_string(),
             text: text.to_string(),
-            has_tools: false,
-            has_thinking: false,
             message_type: role.to_string(),
             query: QueryCondition::Literal {
                 pattern: "test".to_string(),

--- a/src/query/condition.rs
+++ b/src/query/condition.rs
@@ -142,8 +142,6 @@ pub struct SearchResult {
     pub session_id: String,
     pub role: String,
     pub text: String,
-    pub has_tools: bool,
-    pub has_thinking: bool,
     pub message_type: String,
     pub query: QueryCondition,
     pub cwd: String,

--- a/src/schemas/session_message.rs
+++ b/src/schemas/session_message.rs
@@ -555,25 +555,6 @@ impl SessionMessage {
         }
     }
 
-    pub fn has_tool_use(&self) -> bool {
-        match self {
-            SessionMessage::Assistant { message, .. } => message
-                .content
-                .iter()
-                .any(|c| matches!(c, Content::ToolUse { .. })),
-            _ => false,
-        }
-    }
-
-    pub fn has_thinking(&self) -> bool {
-        match self {
-            SessionMessage::Assistant { message, .. } => message
-                .content
-                .iter()
-                .any(|c| matches!(c, Content::Thinking { .. })),
-            _ => false,
-        }
-    }
 
     pub fn get_searchable_text(&self) -> String {
         let mut parts = vec![self.get_content_text()];
@@ -622,8 +603,6 @@ mod tests {
         assert_eq!(msg.get_uuid(), Some("test-uuid"));
         assert_eq!(msg.get_timestamp(), Some("2024-01-01T00:00:00Z"));
         assert_eq!(msg.get_session_id(), Some("test-session"));
-        assert!(!msg.has_tool_use());
-        assert!(!msg.has_thinking());
     }
 
     #[test]
@@ -670,8 +649,6 @@ mod tests {
             msg.get_content_text(),
             "I'll help you with that.\nread_file"
         );
-        assert!(msg.has_tool_use());
-        assert!(!msg.has_thinking());
     }
 
     #[test]
@@ -717,8 +694,6 @@ mod tests {
             msg.get_content_text(),
             "Let me think about this problem...\nHere's my answer."
         );
-        assert!(!msg.has_tool_use());
-        assert!(msg.has_thinking());
     }
 
     #[test]
@@ -876,7 +851,6 @@ mod tests {
             msg.get_content_text(),
             "Starting analysis...\nanalyze_code\nAnalysis complete."
         );
-        assert!(msg.has_tool_use());
     }
 
     #[test]

--- a/src/schemas/session_message.rs
+++ b/src/schemas/session_message.rs
@@ -555,7 +555,6 @@ impl SessionMessage {
         }
     }
 
-
     pub fn get_searchable_text(&self) -> String {
         let mut parts = vec![self.get_content_text()];
 

--- a/src/search/rayon_engine.rs
+++ b/src/search/rayon_engine.rs
@@ -331,9 +331,6 @@ pub(super) fn search_file(
                                 .unwrap_or_else(|| file_ctime.clone())
                         };
 
-                        let has_thinking = message.has_thinking();
-                        let has_tools = message.has_tool_use();
-
                         results.push(SearchResult {
                             timestamp,
                             role: message.get_type().to_string(),
@@ -343,8 +340,6 @@ pub(super) fn search_file(
                             session_id: message.get_session_id().unwrap_or("").to_string(),
                             query: query.clone(),
                             cwd: message.get_cwd().unwrap_or("").to_string(),
-                            has_thinking,
-                            has_tools,
                             message_type: message.get_type().to_string(),
                             raw_json: None,
                         });

--- a/src/search/smol_engine.rs
+++ b/src/search/smol_engine.rs
@@ -388,8 +388,6 @@ async fn search_file(
                                 session_id: message.get_session_id().unwrap_or("").to_string(),
                                 role: message.get_type().to_string(),
                                 text: message.get_content_text(),
-                                has_tools: message.has_tool_use(),
-                                has_thinking: message.has_thinking(),
                                 message_type: message.get_type().to_string(),
                                 query: query_owned.clone(),
                                 cwd: message.get_cwd().unwrap_or("").to_string(),
@@ -1067,7 +1065,6 @@ mod tests {
         // The actual number of results depends on whether thinking content is searched
         assert!(!results.is_empty());
         // At least one message should have thinking or tools
-        assert!(results.iter().any(|r| r.has_thinking || r.has_tools));
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

This PR removes unused `has_thinking` and `has_tools` fields from the `SearchResult` struct and related code.

## Changes

- Removed `has_thinking` and `has_tools` fields from `SearchResult` struct in `src/query/condition.rs`
- Removed `has_thinking()` and `has_tool_use()` methods from `SessionMessage` in `src/schemas/session_message.rs`
- Removed all references to these fields in search engines:
  - `src/search/rayon_engine.rs`
  - `src/search/smol_engine.rs`
- Updated all test files and benchmarks to remove these fields

## Motivation

These fields were not being used anywhere in the codebase. Removing them:
- Simplifies the data structures
- Reduces memory usage
- Removes dead code

## Testing

- [x] All tests pass (`cargo test`)
- [x] Code compiles without warnings (`cargo check`)
- [x] No remaining references to these fields in the codebase

🤖 Generated with [Claude Code](https://claude.ai/code)