### PR TITLE
Fix: Dynamic height calculation for status bars to reduce whitespace

### DIFF
--- a/src/interactive_ratatui/constants.rs
+++ b/src/interactive_ratatui/constants.rs
@@ -52,9 +52,6 @@ pub const MAX_NAVIGATION_HISTORY: usize = 50;
 /// Height of the details header section (role, time, file, project, UUID, session)
 pub const MESSAGE_DETAIL_HEADER_HEIGHT: u16 = 8;
 
-/// Height of the shortcuts bar in message detail view
-pub const MESSAGE_DETAIL_SHORTCUTS_HEIGHT: u16 = 2;
-
 /// Height of the status bar in message detail view
 pub const MESSAGE_DETAIL_STATUS_HEIGHT: u16 = 1;
 
@@ -65,9 +62,6 @@ pub const EXIT_PROMPT_HEIGHT: u16 = 1;
 // Result list layout constants
 /// Height of the title area in result list
 pub const RESULT_LIST_TITLE_HEIGHT: u16 = 2;
-
-/// Height of the status bar in result list
-pub const RESULT_LIST_STATUS_HEIGHT: u16 = 2;
 
 // List viewer default values
 /// Default viewport height for list viewer

--- a/src/interactive_ratatui/ui/components/message_detail.rs
+++ b/src/interactive_ratatui/ui/components/message_detail.rs
@@ -53,6 +53,11 @@ impl MessageDetail {
         let is_exit = is_exit_prompt(&self.message);
         let non_exit_message = if is_exit { None } else { self.message.clone() };
 
+        // Calculate the actual height needed for the shortcuts bar
+        let shortcuts_text = "↑/↓: Scroll | Ctrl+S: View full session | c: Copy message text | C: Copy as JSON | i: Copy session ID | f: Copy file path | p: Copy project path | Alt+←/→: Navigate history | Esc: Back";
+        let shortcuts_paragraph = Paragraph::new(shortcuts_text).wrap(Wrap { trim: true });
+        let shortcuts_height = (shortcuts_paragraph.line_count(area.width) as u16).clamp(1, 3);
+
         // Split the main area into header, message, shortcuts, and optionally status/exit prompt
         let chunks = if is_exit || non_exit_message.is_some() {
             Layout::default()
@@ -60,7 +65,7 @@ impl MessageDetail {
                 .constraints([
                     Constraint::Length(MESSAGE_DETAIL_HEADER_HEIGHT), // Header (fixed)
                     Constraint::Min(5), // Message content (scrollable)
-                    Constraint::Length(MESSAGE_DETAIL_SHORTCUTS_HEIGHT), // Shortcuts (fixed)
+                    Constraint::Length(shortcuts_height), // Shortcuts (dynamic height)
                     Constraint::Length(MESSAGE_DETAIL_STATUS_HEIGHT), // Status/Exit prompt at bottom
                 ])
                 .split(area)
@@ -70,7 +75,7 @@ impl MessageDetail {
                 .constraints([
                     Constraint::Length(MESSAGE_DETAIL_HEADER_HEIGHT), // Header (fixed)
                     Constraint::Min(5), // Message content (scrollable)
-                    Constraint::Length(MESSAGE_DETAIL_SHORTCUTS_HEIGHT), // Shortcuts (fixed)
+                    Constraint::Length(shortcuts_height), // Shortcuts (dynamic height)
                 ])
                 .split(area)
         };

--- a/src/interactive_ratatui/ui/components/result_list.rs
+++ b/src/interactive_ratatui/ui/components/result_list.rs
@@ -68,13 +68,18 @@ impl ResultList {
 
 impl Component for ResultList {
     fn render(&mut self, f: &mut Frame, area: Rect) {
+        // Calculate the actual height needed for the status bar
+        let status_text = "Tab: Filter | ↑/↓ or Ctrl+P/N: Navigate | Enter: View details | Ctrl+S: View full session | Ctrl+T: Toggle preview | Esc: Exit | ?: Help";
+        let status_paragraph = Paragraph::new(status_text).wrap(Wrap { trim: true });
+        let status_height = (status_paragraph.line_count(area.width) as u16).clamp(1, 3);
+        
         // Split area into title, content (list), and status
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
                 Constraint::Length(RESULT_LIST_TITLE_HEIGHT),  // Title
                 Constraint::Min(0),                            // Content (list)
-                Constraint::Length(RESULT_LIST_STATUS_HEIGHT), // Status
+                Constraint::Length(status_height),             // Status (dynamic height)
             ])
             .split(area);
 

--- a/src/interactive_ratatui/ui/components/result_list.rs
+++ b/src/interactive_ratatui/ui/components/result_list.rs
@@ -72,14 +72,14 @@ impl Component for ResultList {
         let status_text = "Tab: Filter | ↑/↓ or Ctrl+P/N: Navigate | Enter: View details | Ctrl+S: View full session | Ctrl+T: Toggle preview | Esc: Exit | ?: Help";
         let status_paragraph = Paragraph::new(status_text).wrap(Wrap { trim: true });
         let status_height = (status_paragraph.line_count(area.width) as u16).clamp(1, 3);
-        
+
         // Split area into title, content (list), and status
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(RESULT_LIST_TITLE_HEIGHT),  // Title
-                Constraint::Min(0),                            // Content (list)
-                Constraint::Length(status_height),             // Status (dynamic height)
+                Constraint::Length(RESULT_LIST_TITLE_HEIGHT), // Title
+                Constraint::Min(0),                           // Content (list)
+                Constraint::Length(status_height),            // Status (dynamic height)
             ])
             .split(area);
 

--- a/src/interactive_ratatui/ui/components/session_viewer.rs
+++ b/src/interactive_ratatui/ui/components/session_viewer.rs
@@ -260,8 +260,9 @@ impl Component for SessionViewer {
             // Calculate the actual number of lines with proper text wrapping
             let lines_needed = paragraph.line_count(area.width) as u16;
 
-            // Ensure minimum of 3 lines, max of 8 lines
-            lines_needed.clamp(3, 8)
+            // Ensure minimum of 1 line, max of 5 lines
+            // SessionViewer has longer status text than other components
+            lines_needed.clamp(1, 5)
         };
 
         // Check if message is exit prompt


### PR DESCRIPTION
## Summary
- Implemented dynamic height calculation for status bars across all interactive UI components
- Eliminates excessive bottom padding that was previously hardcoded
- Improves screen real estate utilization, especially on larger displays

## Changes
- **ResultList**: Status bar height now dynamically adjusts between 1-3 lines based on terminal width
- **MessageDetail**: Shortcuts bar height now dynamically adjusts between 1-3 lines
- **SessionViewer**: Status bar height now adjusts between 1-5 lines (accommodates longer status text)
- Removed unused height constants (`RESULT_LIST_STATUS_HEIGHT`, `MESSAGE_DETAIL_SHORTCUTS_HEIGHT`)

## Technical Details
- Uses `Paragraph::line_count()` to calculate actual lines needed based on text wrapping
- Maintains minimum heights to ensure content is always visible on narrow terminals
- Maximum heights prevent excessive space usage on edge cases

## Testing
- All existing tests pass
- Manually tested on various terminal widths to ensure proper text wrapping
- No visual regressions in any of the interactive modes

## Screenshots
Before: Fixed height causing unnecessary whitespace at the bottom
After: Dynamic height adjusts to actual content needs

🤖 Generated with [Claude Code](https://claude.ai/code)