### PR TITLE
feat: add Ctrl+Z suspend/resume support for interactive mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "signal-hook",
  "smol",
  "sonic-rs",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ async-fs = "2.1"
 futures-lite = "2.5"
 blocking = "1.6"
 
+# Signal handling
+signal-hook = "0.3"
+
 # Performance optimizations
 num_cpus = "1.17"
 

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -458,7 +458,7 @@ impl InteractiveSearch {
         let signal_tx = tx;
         let signal_task = smol::spawn(async move {
             blocking::unblock(move || {
-                if let Ok(mut signals) = Signals::new(&[SIGCONT]) {
+                if let Ok(mut signals) = Signals::new([SIGCONT]) {
                     for sig in signals.forever() {
                         smol::block_on(signal_tx.send(Event::Signal(sig))).ok();
                     }


### PR DESCRIPTION
## Summary

This PR adds support for Ctrl+Z (suspend) and fg (resume) functionality in the interactive mode, allowing users to background the application and restore it properly, similar to standard terminal applications.

## Changes

- Added `signal-hook` dependency for safe signal handling
- Implemented Ctrl+Z handling to properly suspend the process:
  - Cleans up terminal state (exits raw mode and alternate screen)
  - Raises SIGTSTP to suspend the process
- Implemented SIGCONT handler for proper resume:
  - Re-enables raw mode and alternate screen
  - Redraws the UI
- Refactored event system to handle both keyboard events and signals through a unified `Event` enum
- Added separate async tasks for monitoring keyboard input and signals

## Technical Details

When in raw mode, Ctrl+Z is captured as a regular key event rather than generating SIGTSTP automatically. This implementation:
1. Detects Ctrl+Z key press
2. Restores terminal to normal mode
3. Manually raises SIGTSTP to suspend the process
4. On SIGCONT (when user runs `fg`), re-initializes the terminal and UI

## Testing

- Built and tested manually with `cargo build --release`
- Verified Ctrl+Z suspends the application properly
- Verified `fg` resumes the application with UI intact
- Existing functionality remains unchanged

## Related Issue

Addresses the need for standard terminal suspend/resume behavior in interactive mode.