### PR TITLE
fix: message detail scroll offset not being preserved

### DIFF
--- a/src/interactive_ratatui/ui/components/message_detail.rs
+++ b/src/interactive_ratatui/ui/components/message_detail.rs
@@ -19,7 +19,7 @@ pub struct MessageDetail {
     pub(super) result: Option<SearchResult>,
     pub(super) scroll_offset: usize,
     pub(super) message: Option<String>,
-    current_uuid: Option<String>,
+    pub(super) current_uuid: Option<String>,
 }
 
 impl MessageDetail {

--- a/src/interactive_ratatui/ui/components/message_detail.rs
+++ b/src/interactive_ratatui/ui/components/message_detail.rs
@@ -19,6 +19,7 @@ pub struct MessageDetail {
     pub(super) result: Option<SearchResult>,
     pub(super) scroll_offset: usize,
     pub(super) message: Option<String>,
+    current_uuid: Option<String>,
 }
 
 impl MessageDetail {
@@ -27,17 +28,26 @@ impl MessageDetail {
             result: None,
             scroll_offset: 0,
             message: None,
+            current_uuid: None,
         }
     }
 
     pub fn set_result(&mut self, result: SearchResult) {
+        // Only reset scroll if it's a different message
+        let should_reset_scroll = self.current_uuid.as_ref() != Some(&result.uuid);
+        
+        if should_reset_scroll {
+            self.scroll_offset = 0;
+            self.current_uuid = Some(result.uuid.clone());
+        }
+        
         self.result = Some(result);
-        self.scroll_offset = 0;
     }
 
     pub fn clear(&mut self) {
         self.result = None;
         self.scroll_offset = 0;
+        self.current_uuid = None;
     }
 
     pub fn set_message(&mut self, message: Option<String>) {

--- a/src/interactive_ratatui/ui/components/message_detail.rs
+++ b/src/interactive_ratatui/ui/components/message_detail.rs
@@ -35,12 +35,12 @@ impl MessageDetail {
     pub fn set_result(&mut self, result: SearchResult) {
         // Only reset scroll if it's a different message
         let should_reset_scroll = self.current_uuid.as_ref() != Some(&result.uuid);
-        
+
         if should_reset_scroll {
             self.scroll_offset = 0;
             self.current_uuid = Some(result.uuid.clone());
         }
-        
+
         self.result = Some(result);
     }
 

--- a/src/interactive_ratatui/ui/components/message_detail_test.rs
+++ b/src/interactive_ratatui/ui/components/message_detail_test.rs
@@ -619,7 +619,7 @@ mod tests {
 
         // Set the same message again (simulating re-render)
         detail.set_result(result.clone());
-        
+
         // Scroll offset should be preserved
         assert_eq!(detail.scroll_offset, 10);
         assert_eq!(detail.current_uuid, Some(uuid.clone()));
@@ -634,7 +634,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         result1.uuid = "message-1-uuid".to_string();
-        
+
         detail.set_result(result1);
 
         // Scroll down 10 lines
@@ -650,9 +650,9 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n");
         result2.uuid = "message-2-uuid".to_string();
-        
+
         detail.set_result(result2);
-        
+
         // Scroll offset should be reset to 0
         assert_eq!(detail.scroll_offset, 0);
         assert_eq!(detail.current_uuid, Some("message-2-uuid".to_string()));
@@ -663,10 +663,10 @@ mod tests {
         let mut detail = MessageDetail::new();
         let result = create_test_result();
         let uuid = result.uuid.clone();
-        
+
         detail.set_result(result);
         assert_eq!(detail.current_uuid, Some(uuid));
-        
+
         detail.clear();
         assert!(detail.current_uuid.is_none());
         assert_eq!(detail.scroll_offset, 0);

--- a/src/interactive_ratatui/ui/components/message_detail_test.rs
+++ b/src/interactive_ratatui/ui/components/message_detail_test.rs
@@ -598,4 +598,77 @@ mod tests {
         assert!(content.contains("Message") && content.contains("of 20"));
         assert!(content.contains("Line 5")); // Should see line 5 after scrolling 5 times
     }
+
+    #[test]
+    fn test_scroll_offset_preserved_on_same_message() {
+        let mut detail = MessageDetail::new();
+        let mut result = create_test_result();
+        // Create a message with many lines to enable scrolling
+        result.text = (0..50)
+            .map(|i| format!("Line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let uuid = result.uuid.clone();
+        detail.set_result(result.clone());
+
+        // Scroll down 10 lines
+        for _ in 0..10 {
+            detail.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()));
+        }
+        assert_eq!(detail.scroll_offset, 10);
+
+        // Set the same message again (simulating re-render)
+        detail.set_result(result.clone());
+        
+        // Scroll offset should be preserved
+        assert_eq!(detail.scroll_offset, 10);
+        assert_eq!(detail.current_uuid, Some(uuid.clone()));
+    }
+
+    #[test]
+    fn test_scroll_offset_reset_on_different_message() {
+        let mut detail = MessageDetail::new();
+        let mut result1 = create_test_result();
+        result1.text = (0..50)
+            .map(|i| format!("Message 1 Line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        result1.uuid = "message-1-uuid".to_string();
+        
+        detail.set_result(result1);
+
+        // Scroll down 10 lines
+        for _ in 0..10 {
+            detail.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::empty()));
+        }
+        assert_eq!(detail.scroll_offset, 10);
+
+        // Set a different message
+        let mut result2 = create_test_result();
+        result2.text = (0..50)
+            .map(|i| format!("Message 2 Line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        result2.uuid = "message-2-uuid".to_string();
+        
+        detail.set_result(result2);
+        
+        // Scroll offset should be reset to 0
+        assert_eq!(detail.scroll_offset, 0);
+        assert_eq!(detail.current_uuid, Some("message-2-uuid".to_string()));
+    }
+
+    #[test]
+    fn test_clear_resets_current_uuid() {
+        let mut detail = MessageDetail::new();
+        let result = create_test_result();
+        let uuid = result.uuid.clone();
+        
+        detail.set_result(result);
+        assert_eq!(detail.current_uuid, Some(uuid));
+        
+        detail.clear();
+        assert!(detail.current_uuid.is_none());
+        assert_eq!(detail.scroll_offset, 0);
+    }
 }

--- a/src/interactive_ratatui/ui/renderer.rs
+++ b/src/interactive_ratatui/ui/renderer.rs
@@ -43,10 +43,6 @@ impl Renderer {
     }
 
     pub fn render(&mut self, f: &mut Frame, state: &AppState) {
-        let _ = crate::interactive_ratatui::debug::write_debug_log(&format!(
-            "Renderer::render called with mode: {:?}",
-            state.mode
-        ));
         match state.mode {
             Mode::Search => self.render_search_mode(f, state),
             Mode::MessageDetail => self.render_detail_mode(f, state),
@@ -206,22 +202,10 @@ impl Renderer {
     }
 
     fn render_detail_mode(&mut self, f: &mut Frame, state: &AppState) {
-        let _ = crate::interactive_ratatui::debug::write_debug_log(&format!(
-            "Renderer::render_detail_mode called, selected_result: {}",
-            state.ui.selected_result.is_some()
-        ));
         if let Some(result) = &state.ui.selected_result {
-            let _ = crate::interactive_ratatui::debug::write_debug_log(&format!(
-                "Renderer::render_detail_mode: rendering result with uuid: {}",
-                result.uuid
-            ));
             self.message_detail.set_result(result.clone());
             self.message_detail.set_message(state.ui.message.clone());
             self.message_detail.render(f, f.area());
-        } else {
-            let _ = crate::interactive_ratatui::debug::write_debug_log(
-                "Renderer::render_detail_mode: No selected_result to render!",
-            );
         }
     }
 
@@ -238,10 +222,6 @@ impl Renderer {
         self.session_viewer.set_message(state.ui.message.clone());
         self.session_viewer
             .set_role_filter(state.session.role_filter.clone());
-        let _ = crate::interactive_ratatui::debug::write_debug_log(&format!(
-            "Renderer::render_session_mode: setting preview_enabled = {}",
-            state.session.preview_enabled
-        ));
         self.session_viewer
             .set_preview_enabled(state.session.preview_enabled);
         // Restore the selected index


### PR DESCRIPTION
## Summary
- Fixed an issue where the scroll position in the message detail view was being reset on every render
- Added UUID tracking to only reset scroll when viewing a different message
- Removed debug logging code that was added during troubleshooting

## Problem
The message detail view was calling `set_result()` on every render cycle, which was resetting the scroll offset to 0 even when viewing the same message. This made it impossible to scroll through long messages.

## Solution
- Added `current_uuid` field to track the currently displayed message
- Only reset scroll offset when the UUID changes (i.e., when viewing a different message)
- Keep scroll position when re-rendering the same message

## Test plan
1. Run the interactive mode: `./target/release/ccms --interactive`
2. Search for messages and select one with multiple lines of content
3. Use arrow keys or PageUp/PageDown to scroll
4. Verify that the scroll position is maintained while viewing the same message
5. Select a different message and verify that scroll position resets to top