### PR TITLE
Display file path in session list preview

### DIFF
--- a/src/interactive_ratatui/ui/components/session_list.rs
+++ b/src/interactive_ratatui/ui/components/session_list.rs
@@ -133,6 +133,11 @@ impl Component for SessionList {
                             format!("[{}]", session.session_id),
                             Style::default().fg(Color::Cyan),
                         ),
+                        Span::raw(" "),
+                        Span::styled(
+                            &session.file_path,
+                            Style::default().fg(Color::Green),
+                        ),
                         Span::raw(format!(" {} messages - ", session.message_count)),
                         Span::styled(&session.first_message, Style::default().fg(Color::DarkGray)),
                     ]);


### PR DESCRIPTION
## Summary
- Added file path display to session list preview
- Shows full file path in green color between session ID and message count
- Improves user experience by providing better context about which file contains the session

## Test plan
- [x] Build passes with `cargo build --release`
- [x] All tests pass with `cargo test`
- [x] Manually tested session list display shows file paths correctly