### PR TITLE
Add cargo fmt and clippy hooks for code quality

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd $CLAUDE_PROJECT_DIR && cargo fmt",
+            "timeout": 30
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cd $CLAUDE_PROJECT_DIR && cargo clippy -- -D warnings",
+            "timeout": 60
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
This PR adds Claude Code hooks to automatically maintain code quality in the ccms project.

## Changes
- Added `.claude/settings.json` with two hooks:
  - **cargo fmt hook**: Automatically formats code after `Edit` or `MultiEdit` tool usage
  - **cargo clippy hook**: Runs clippy with warnings as errors when a Claude Code session ends

## Benefits
- Ensures consistent code formatting across all edits
- Catches potential issues and enforces Rust best practices
- Maintains high code quality standards automatically

## Test plan
The hooks will be tested automatically through normal Claude Code usage:
1. Editing any Rust file will trigger cargo fmt
2. Ending a Claude Code session will run cargo clippy