### PR TITLE
refactor: change UUID label to Message ID in message detail view

### DIFF
--- a/src/interactive_ratatui/integration_tests.rs
+++ b/src/interactive_ratatui/integration_tests.rs
@@ -797,7 +797,7 @@ mod tests {
         assert!(buffer_contains(buffer, "CWD: /test/project"));
         assert!(buffer_contains(
             buffer,
-            "UUID: 12345678-1234-5678-1234-567812345678"
+            "Message ID: 12345678-1234-5678-1234-567812345678"
         ));
         assert!(buffer_contains(
             buffer,

--- a/src/interactive_ratatui/ui/components/message_detail.rs
+++ b/src/interactive_ratatui/ui/components/message_detail.rs
@@ -119,7 +119,7 @@ impl MessageDetail {
                 Span::raw(&result.cwd),
             ]),
             Line::from(vec![
-                Span::styled("UUID: ", Styles::label()),
+                Span::styled("Message ID: ", Styles::label()),
                 Span::raw(&result.uuid),
             ]),
             Line::from(vec![

--- a/src/interactive_ratatui/ui/components/message_detail_test.rs
+++ b/src/interactive_ratatui/ui/components/message_detail_test.rs
@@ -322,7 +322,7 @@ mod tests {
         assert!(content.contains("File:"));
         assert!(content.contains("CWD:"));
         assert!(content.contains("Session:"));
-        assert!(content.contains("UUID:"));
+        assert!(content.contains("Message ID:"));
 
         // With narrow width, long values might be truncated or on next lines
         // Just check that some parts of the values are present
@@ -526,7 +526,7 @@ mod tests {
         assert!(content.contains("Time:"));
         assert!(content.contains("File: /path/to/test.jsonl"));
         assert!(content.contains("CWD: /path/to/project"));
-        assert!(content.contains("UUID: 12345678-1234-5678-1234-567812345678"));
+        assert!(content.contains("Message ID: 12345678-1234-5678-1234-567812345678"));
         assert!(content.contains("Session: session-123"));
 
         // Shortcuts should be visible in the status bar


### PR DESCRIPTION
## Summary
- Changed the label from "UUID" to "Message ID" in the message detail component
- This makes it clearer that the field represents the unique message identifier

## Changes
- Updated label in `message_detail.rs` header from "UUID:" to "Message ID:"
- Updated corresponding test assertions in `message_detail_test.rs`
- Updated integration test assertion in `integration_tests.rs`

## Test plan
- [x] All existing tests pass
- [x] Manually verified the label displays correctly in the UI