### PR TITLE
feat: Use Shift+Tab to toggle between Search and Session List tabs

### DIFF
--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -323,7 +323,13 @@ impl InteractiveSearch {
         } else if self.state.search.current_tab == SearchTab::SessionList {
             // In session list tab, handle specific keys
             match key.code {
-                KeyCode::Tab => return Some(Message::SwitchToSearchTab),
+                // Use Shift+Tab to toggle between tabs
+                KeyCode::BackTab => {
+                    // Let tab bar handle Shift+Tab for consistency
+                    if let Some(msg) = self.renderer.get_tab_bar_mut().handle_key(key) {
+                        return Some(msg);
+                    }
+                }
                 KeyCode::Esc => {
                     // Let tab bar handle Esc to close the tab
                     if let Some(msg) = self.renderer.get_tab_bar_mut().handle_key(key) {


### PR DESCRIPTION
## Summary
- Changed tab navigation to use Shift+Tab consistently for toggling between Search and Session List tabs
- Removed Tab key handling from Session List tab for better consistency
- Fixed clippy warning about lifetime elision in text_input.rs

## Details
Previously, the tab navigation was asymmetric:
- Search → Session List: Shift+Tab
- Session List → Search: Tab

Now both directions use Shift+Tab for a more consistent user experience.

## Test plan
- [x] Run `cargo test` to ensure all tests pass
- [x] Run `cargo clippy` to ensure no warnings
- [x] Manually test tab switching in interactive mode

🤖 Generated with [Claude Code](https://claude.ai/code)