### PR TITLE
fix: correct session list glob pattern for project-specific searches

### DIFF
--- a/src/interactive_ratatui/application/search_service.rs
+++ b/src/interactive_ratatui/application/search_service.rs
@@ -124,7 +124,8 @@ impl SearchService {
             };
 
             let encoded_path = encode_project_path(&absolute_path);
-            let claude_project_dir = format!("~/.claude/projects/{encoded_path}*/**/*.jsonl");
+            // Use wildcard to include related projects
+            let claude_project_dir = format!("~/.claude/projects/{encoded_path}*/*.jsonl");
 
             discover_claude_files(Some(&claude_project_dir))?
         } else {


### PR DESCRIPTION
## Summary
- Fixed session list not displaying when using `--project` flag
- Changed glob pattern from `/**/*.jsonl` to `*/*.jsonl` to match Claude's flat directory structure

## Problem
When running `ccms --project /path/to/project`, the session list tab would show no sessions even though sessions existed for that project. The issue was with the glob pattern used to discover session files.

## Solution
The original pattern `~/.claude/projects/{encoded_path}*/**/*.jsonl` was looking for files in subdirectories, but Claude stores session files directly in the project directory. Changed to `~/.claude/projects/{encoded_path}*/*.jsonl` to match the actual directory structure.

## Test plan
- [x] Build and run `ccms --project $(pwd)` in a project with Claude sessions
- [x] Switch to Session List tab (Shift+Tab)
- [x] Verify sessions are displayed correctly
- [x] Verify search functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)