### PR TITLE
fix: display search errors in UI and clear them when corrected

### DIFF
--- a/src/interactive_ratatui/application/search_service.rs
+++ b/src/interactive_ratatui/application/search_service.rs
@@ -40,6 +40,7 @@ impl SearchService {
         Ok(SearchResponse {
             id: request.id,
             results,
+            error: None,
         })
     }
 
@@ -60,6 +61,7 @@ impl SearchService {
         Ok(SearchResponse {
             id: request.id,
             results,
+            error: None,
         })
     }
 

--- a/src/interactive_ratatui/domain/models.rs
+++ b/src/interactive_ratatui/domain/models.rs
@@ -48,4 +48,5 @@ pub struct SearchRequest {
 pub struct SearchResponse {
     pub id: u64,
     pub results: Vec<SearchResult>,
+    pub error: Option<String>,
 }

--- a/src/interactive_ratatui/domain/models_test.rs
+++ b/src/interactive_ratatui/domain/models_test.rs
@@ -75,6 +75,7 @@ mod tests {
         let response = SearchResponse {
             id: 42,
             results: results.clone(),
+            error: None,
         };
 
         assert_eq!(response.id, 42);


### PR DESCRIPTION
## Summary

This PR fixes an issue where search errors would persist in the interactive UI even after correcting the query.

## Problem

When entering an invalid query (e.g., "/") in the search input, the error message would remain displayed even after deleting the invalid character and entering a valid query.

## Solution

- Added an  field to  to propagate errors from the search worker to the UI
- Modified the search worker to include errors in the response instead of printing to stderr
- Updated the UI to display search errors in the status bar
- Leveraged existing status clearing mechanism to remove errors when a valid search completes

## Testing

- All existing tests pass
- Manual testing confirms:
  - Parse errors are displayed when entering invalid queries
  - Errors are automatically cleared when a valid search completes
  - No regressions in normal search functionality

## Screenshots

Before: Errors printed to stderr, not visible in UI
After: Errors displayed in status bar and cleared on successful search