### PR TITLE
feat: improve session list UI with keyboard shortcuts and layout fixes

### DIFF
--- a/src/interactive_ratatui/ui/components/session_list.rs
+++ b/src/interactive_ratatui/ui/components/session_list.rs
@@ -78,13 +78,22 @@ impl SessionList {
 
 impl Component for SessionList {
     fn render(&mut self, f: &mut Frame, area: Rect) {
+        // Calculate the actual height needed for the status bar
+        let status_text = if self.preview_enabled {
+            "Shift+Tab: Switch tabs | ↑/↓: Navigate | Ctrl+U/D: Half page | Enter: Open session | Ctrl+S: View session | Ctrl+T: Hide preview | Esc: Exit | ?: Help"
+        } else {
+            "Shift+Tab: Switch tabs | ↑/↓: Navigate | Ctrl+U/D: Half page | Enter: Open session | Ctrl+S: View session | Ctrl+T: Show preview | Esc: Exit | ?: Help"
+        };
+        let status_paragraph = Paragraph::new(status_text).wrap(Wrap { trim: true });
+        let status_height = (status_paragraph.line_count(area.width) as u16).clamp(1, 3);
+
         // Split area into search bar, sessions list and status bar
         let chunks = Layout::default()
             .direction(Direction::Vertical)
             .constraints([
-                Constraint::Length(3), // Search bar
-                Constraint::Min(0),    // Sessions list
-                Constraint::Length(2), // Status bar
+                Constraint::Length(3),             // Search bar
+                Constraint::Min(0),                // Sessions list
+                Constraint::Length(status_height), // Status bar (dynamic height)
             ])
             .split(area);
 
@@ -185,11 +194,6 @@ impl Component for SessionList {
         }
 
         // Render status bar
-        let status_text = if self.preview_enabled {
-            "Shift+Tab: Switch tabs | ↑/↓: Navigate | Enter: Open session | Ctrl+S: View session | Ctrl+T: Hide preview | Esc: Exit | ?: Help"
-        } else {
-            "Shift+Tab: Switch tabs | ↑/↓: Navigate | Enter: Open session | Ctrl+S: View session | Ctrl+T: Show preview | Esc: Exit | ?: Help"
-        };
         let status_bar = Paragraph::new(status_text)
             .style(Style::default().fg(Color::DarkGray))
             .alignment(ratatui::layout::Alignment::Center)


### PR DESCRIPTION
## Summary
- Add Ctrl+U/D keyboard shortcuts to the session list status bar for better discoverability
- Fix extra blank line rendering issue below the status bar by implementing dynamic height calculation

## Changes
1. **Added keyboard shortcuts to status bar**: The status bar now displays "Ctrl+U/D: Half page" to inform users about the half-page scrolling functionality that was already implemented but not visible
2. **Dynamic status bar height**: Implemented dynamic height calculation based on text wrapping, similar to the search results component, eliminating the extra blank line that was rendering below the shortcuts

## Test Plan
- [x] Build passes with `cargo build`
- [ ] Interactive mode displays the shortcuts correctly
- [ ] Status bar wraps properly on narrow terminals without extra blank lines
- [ ] Half-page scrolling (Ctrl+U/D) continues to work as expected