### PR TITLE
feat: add enhanced JSON output format with session and file statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ ccms --full-text "query"
 # Show raw JSON of matched messages
 ccms --raw "query"
 
-# JSON output
+# JSON output with detailed statistics
 ccms -f json "query" > results.json
 
 # JSONL output (one JSON per line)
@@ -259,6 +259,30 @@ ccms -f jsonl "query" > results.jsonl
 # Verbose output with debug info
 ccms -v "query"
 ```
+
+#### JSON Output Format
+
+The JSON output format provides rich metadata about search results:
+
+```bash
+# Get detailed JSON output with session and file statistics
+ccms -f json "error" --project "/" -n 100
+
+# Extract summary information
+ccms -f json "query" | jq '.summary'
+
+# List all unique sessions with message counts
+ccms -f json "query" | jq -r '.sessions[] | "\(.session_id): \(.message_count) messages"'
+
+# List all unique files with message counts
+ccms -f json "query" | jq -r '.files[] | "\(.message_count) messages: \(.path)"'
+```
+
+JSON output structure includes:
+- `results`: Array of search results with full message details
+- `summary`: Search statistics including duration, total/returned counts, unique sessions/files
+- `sessions`: List of unique sessions with message counts
+- `files`: List of unique files with message counts and associated session IDs
 
 ## CLI Options
 

--- a/spec.md
+++ b/spec.md
@@ -570,3 +570,68 @@ Recent enhancements include:
 - Search result highlighting in Session Viewer
 - Automatic text wrapping for long file paths in Message Detail and Session Viewer
 - Unified exit mechanism (Ctrl+C twice) - ESC no longer exits from search screen
+
+## JSON Output Format Specification
+
+The JSON output format (`-f json`) provides structured data with comprehensive metadata about search results.
+
+### JSON Structure
+
+```json
+{
+  "results": [...],
+  "summary": {...},
+  "files": [...],
+  "sessions": [...]
+}
+```
+
+### Field Descriptions
+
+#### `results` (Array)
+An array of search result objects, each containing:
+- `uuid`: Unique message identifier
+- `timestamp`: ISO 8601 timestamp
+- `session_id`: Session UUID
+- `role`: Message role (user, assistant, system, summary)
+- `text`: Message content (may be truncated unless `--full-text` is used)
+- `message_type`: Type of message
+- `file`: Full path to the JSONL file
+- `cwd`: Working directory when the message was created
+- `query`: The query condition that matched this result
+- `raw_json`: Optional raw JSON (included when `--raw` is used)
+
+#### `summary` (Object)
+Search statistics:
+- `duration_ms`: Search execution time in milliseconds
+- `total_count`: Total number of matches found
+- `returned_count`: Number of results returned (limited by `-n`)
+- `unique_sessions`: Number of unique session IDs in results
+- `unique_files`: Number of unique JSONL files in results
+
+#### `files` (Array)
+List of unique files containing matches:
+- `path`: Full path to the JSONL file
+- `message_count`: Number of messages from this file in the results
+- `session_id`: The session ID associated with this file
+
+#### `sessions` (Array)
+List of unique sessions containing matches:
+- `session_id`: Session UUID
+- `message_count`: Number of messages from this session in the results
+
+### Example Usage
+
+```bash
+# Get JSON output
+ccms -f json "error" > results.json
+
+# Extract session IDs
+ccms -f json "query" | jq -r '.sessions[].session_id'
+
+# Get file statistics
+ccms -f json "query" | jq '.summary'
+
+# List files with message counts
+ccms -f json "query" | jq -r '.files[] | "\(.message_count) messages: \(.path)"'
+```


### PR DESCRIPTION
## Summary
This PR enhances the JSON output format (`-f json`) to include comprehensive metadata about search results, making it easier to analyze sessions and files programmatically.

## Changes
- Enhanced JSON output structure with four main sections:
  - `results`: Array of search results (existing)
  - `summary`: Search statistics including unique session/file counts (new)
  - `sessions`: List of unique sessions with message counts (new)
  - `files`: List of unique files with message counts and session IDs (new)
- Updated documentation in README.md and spec.md

## Benefits
- Easy extraction of unique session IDs and file paths
- Message count statistics per session and file
- No need for external scripts to analyze search results
- Improved programmatic access to search metadata

## Example Usage
```bash
# Get summary statistics
ccms -f json "query" | jq '.summary'

# List all unique sessions with message counts
ccms -f json "query" | jq -r '.sessions[] | "\(.session_id): \(.message_count) messages"'

# Extract just session IDs
ccms -f json "query" | jq -r '.sessions[].session_id'
```

## Testing
The changes have been tested with various queries and the JSON output correctly includes all metadata fields.