### PR TITLE
feat: add --stats option to display search statistics

### DIFF
--- a/benches/statistics_benchmark.rs
+++ b/benches/statistics_benchmark.rs
@@ -1,0 +1,221 @@
+use ccms::{QueryCondition, SearchResult, Statistics, format_statistics};
+use codspeed_criterion_compat::{
+    BenchmarkId, Criterion, black_box, criterion_group, criterion_main,
+};
+use std::collections::HashSet;
+
+// Generate test search results for benchmarking
+fn generate_search_results(
+    num_results: usize,
+    num_sessions: usize,
+    num_files: usize,
+) -> Vec<SearchResult> {
+    let mut results = Vec::with_capacity(num_results);
+
+    for i in 0..num_results {
+        let session_id = format!("session{}", i % num_sessions);
+        let file_id = format!("file{}.jsonl", i % num_files);
+        let role = if i % 3 == 0 {
+            "user"
+        } else if i % 3 == 1 {
+            "assistant"
+        } else {
+            "system"
+        };
+        let message_type = if i % 5 == 0 { "summary" } else { "message" };
+
+        results.push(SearchResult {
+            file: file_id,
+            uuid: format!("uuid-{i}"),
+            timestamp: format!(
+                "2024-01-01T{:02}:{:02}:{:02}Z",
+                i / 3600 % 24,
+                i / 60 % 60,
+                i % 60
+            ),
+            session_id,
+            role: role.to_string(),
+            text: format!("Test message content {i}"),
+            message_type: message_type.to_string(),
+            query: QueryCondition::Literal {
+                pattern: "test".to_string(),
+                case_sensitive: false,
+            },
+            cwd: format!("/project{}", i % 5),
+            raw_json: None,
+        });
+    }
+
+    results
+}
+
+fn benchmark_statistics_collection(c: &mut Criterion) {
+    let mut group = c.benchmark_group("statistics_collection");
+
+    // Benchmark with different numbers of results
+    for num_results in [100, 1000, 10000, 50000].iter() {
+        let results = generate_search_results(*num_results, 10, 20);
+
+        group.bench_with_input(
+            BenchmarkId::new("collect_stats", num_results),
+            &results,
+            |b, results| {
+                b.iter(|| {
+                    let mut stats = Statistics::new();
+                    for result in results {
+                        stats.add_message(
+                            &result.role,
+                            &result.session_id,
+                            &result.file,
+                            &result.timestamp,
+                            &result.cwd,
+                            &result.message_type,
+                        );
+                    }
+                    black_box(stats)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn benchmark_statistics_formatting(c: &mut Criterion) {
+    let mut group = c.benchmark_group("statistics_formatting");
+
+    // Create a populated statistics object
+    let results = generate_search_results(10000, 50, 100);
+    let mut stats = Statistics::new();
+    for result in &results {
+        stats.add_message(
+            &result.role,
+            &result.session_id,
+            &result.file,
+            &result.timestamp,
+            &result.cwd,
+            &result.message_type,
+        );
+    }
+
+    group.bench_function("format_with_color", |b| {
+        b.iter(|| {
+            let output = format_statistics(&stats, true);
+            black_box(output)
+        });
+    });
+
+    group.bench_function("format_without_color", |b| {
+        b.iter(|| {
+            let output = format_statistics(&stats, false);
+            black_box(output)
+        });
+    });
+
+    group.finish();
+}
+
+fn benchmark_unique_tracking(c: &mut Criterion) {
+    let mut group = c.benchmark_group("unique_tracking");
+
+    // Benchmark HashSet insertion performance for different unique counts
+    for unique_count in [10, 100, 1000, 10000].iter() {
+        group.bench_with_input(
+            BenchmarkId::new("hashset_insert", unique_count),
+            unique_count,
+            |b, &unique_count| {
+                b.iter(|| {
+                    let mut set = HashSet::new();
+                    for i in 0..unique_count {
+                        set.insert(format!("item-{i}"));
+                    }
+                    // Add duplicates to test real-world scenario
+                    for i in 0..unique_count / 2 {
+                        set.insert(format!("item-{i}"));
+                    }
+                    black_box(set.len())
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn benchmark_timestamp_comparison(c: &mut Criterion) {
+    let mut group = c.benchmark_group("timestamp_comparison");
+
+    let timestamps: Vec<String> = (0..1000)
+        .map(|i| {
+            format!(
+                "2024-01-01T{:02}:{:02}:{:02}Z",
+                i / 3600 % 24,
+                i / 60 % 60,
+                i % 60
+            )
+        })
+        .collect();
+
+    group.bench_function("string_comparison", |b| {
+        b.iter(|| {
+            let mut earliest = timestamps[0].clone();
+            let mut latest = timestamps[0].clone();
+
+            for timestamp in &timestamps {
+                if timestamp < &earliest {
+                    earliest = timestamp.clone();
+                }
+                if timestamp > &latest {
+                    latest = timestamp.clone();
+                }
+            }
+            black_box((earliest, latest))
+        });
+    });
+
+    group.finish();
+}
+
+fn benchmark_collect_statistics_from_results(c: &mut Criterion) {
+    let mut group = c.benchmark_group("collect_statistics_from_results");
+
+    // This benchmarks the actual collect_statistics function pattern
+    for num_results in [100, 1000, 10000].iter() {
+        let results = generate_search_results(*num_results, 20, 50);
+
+        group.bench_with_input(
+            BenchmarkId::new("from_search_results", num_results),
+            &results,
+            |b, results| {
+                b.iter(|| {
+                    // Simulate the collect_statistics pattern from main.rs
+                    let mut stats = Statistics::new();
+                    for result in results {
+                        stats.add_message(
+                            &result.role,
+                            &result.session_id,
+                            &result.file,
+                            &result.timestamp,
+                            &result.cwd,
+                            &result.message_type,
+                        );
+                    }
+                    black_box(stats)
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    benchmark_statistics_collection,
+    benchmark_statistics_formatting,
+    benchmark_unique_tracking,
+    benchmark_timestamp_comparison,
+    benchmark_collect_statistics_from_results
+);
+
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod profiling_enhanced;
 pub mod query;
 pub mod schemas;
 pub mod search;
+pub mod stats;
 pub mod utils;
 
 pub use query::{QueryCondition, SearchOptions, SearchResult, parse_query};
@@ -13,3 +14,4 @@ pub use search::{
     RayonEngine, SearchEngineTrait, SmolEngine, default_claude_pattern, discover_claude_files,
     expand_tilde, format_search_result,
 };
+pub use stats::{Statistics, format_statistics};

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,7 +272,11 @@ fn main() -> Result<()> {
 
     // Create search options
     let options = SearchOptions {
-        max_results: Some(cli.max_results),
+        max_results: if cli.stats {
+            None // Don't limit results when calculating statistics
+        } else {
+            Some(cli.max_results)
+        },
         role: cli.role,
         session_id: cli.session_id,
         message_id: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,9 @@ use anyhow::Result;
 #[cfg(feature = "profiling")]
 use ccms::profiling_enhanced;
 use ccms::{
-    RayonEngine, SearchEngineTrait, SearchOptions, SearchResult, SmolEngine,
-    default_claude_pattern, format_search_result, interactive_ratatui::InteractiveSearch,
-    parse_query, profiling,
+    QueryCondition, RayonEngine, SearchEngineTrait, SearchOptions, SearchResult, SmolEngine,
+    Statistics, default_claude_pattern, format_search_result,
+    interactive_ratatui::InteractiveSearch, parse_query, profiling,
 };
 use chrono::{DateTime, Local, Utc};
 use clap::{Command, CommandFactory, Parser, ValueEnum};
@@ -103,6 +103,10 @@ struct Cli {
     /// Search engine to use
     #[arg(long, value_enum, default_value = "smol")]
     engine: EngineType,
+
+    /// Show only statistics
+    #[arg(long)]
+    stats: bool,
 }
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
@@ -226,8 +230,10 @@ fn main() -> Result<()> {
         return Ok(());
     }
 
-    // Interactive mode when no query provided or query is empty
-    if cli.query.is_none() || cli.query.as_ref().map(|s| s.is_empty()).unwrap_or(false) {
+    // Interactive mode when no query provided or query is empty (but not when --stats is used)
+    if !cli.stats
+        && (cli.query.is_none() || cli.query.as_ref().map(|s| s.is_empty()).unwrap_or(false))
+    {
         let options = SearchOptions {
             max_results: Some(cli.max_results), // Use the CLI value directly
             role: cli.role,
@@ -243,16 +249,24 @@ fn main() -> Result<()> {
         return interactive.run(pattern);
     }
 
-    // Regular search mode - query is provided
-    let query_str = cli.query.unwrap();
+    // Regular search mode - query is provided (or empty string for --stats)
+    let query_str = cli.query.unwrap_or_else(String::new);
 
-    // Parse the query
-    let query = match parse_query(&query_str) {
-        Ok(q) => q,
-        Err(e) => {
-            eprintln!("Error parsing query: {e}");
-            eprintln!("Use --help-query for query syntax help");
-            std::process::exit(1);
+    // Parse the query (empty query for --stats means match all)
+    let query = if cli.stats && query_str.is_empty() {
+        // Empty query for stats: match everything
+        QueryCondition::Literal {
+            pattern: String::new(),
+            case_sensitive: false,
+        }
+    } else {
+        match parse_query(&query_str) {
+            Ok(q) => q,
+            Err(e) => {
+                eprintln!("Error parsing query: {e}");
+                eprintln!("Use --help-query for query syntax help");
+                std::process::exit(1);
+            }
         }
     };
 
@@ -304,6 +318,22 @@ fn main() -> Result<()> {
             engine.search(pattern_to_use, query)?
         }
     };
+
+    // If stats flag is set, collect and display statistics
+    if cli.stats {
+        let stats = collect_statistics(&results);
+        println!("{}", ccms::stats::format_statistics(&stats, !cli.no_color));
+
+        eprintln!("\n⏱️  Search completed in {}ms", duration.as_millis());
+        if total_count > results.len() {
+            eprintln!(
+                "(Showing stats for {} of {} total results)",
+                results.len(),
+                total_count
+            );
+        }
+        return Ok(());
+    }
 
     // Output results
     let stdout = io::stdout();
@@ -497,6 +527,23 @@ fn print_message_details(result: &SearchResult, use_color: bool) {
     }
 }
 
+fn collect_statistics(results: &[SearchResult]) -> Statistics {
+    let mut stats = Statistics::new();
+
+    for result in results {
+        stats.add_message(
+            &result.role,
+            &result.session_id,
+            &result.file,
+            &result.timestamp,
+            &result.cwd,
+            &result.message_type,
+        );
+    }
+
+    stats
+}
+
 fn print_query_help() {
     println!(
         r#"Claude Search Query Syntax Help
@@ -531,7 +578,8 @@ TIPS:
   - Unquoted literals cannot contain spaces or special characters
   - Use quotes for exact phrases with spaces
   - Regular expressions must be enclosed in forward slashes
-  - AND has higher precedence than OR"#
+  - AND has higher precedence than OR
+  - Use --stats flag to see only statistics without message content"#
     );
 }
 
@@ -561,6 +609,76 @@ mod tests {
         // Test invalid input
         let result = parse_since_time("invalid time");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_collect_statistics() {
+        use ccms::query::QueryCondition;
+
+        let results = vec![
+            SearchResult {
+                file: "file1.jsonl".to_string(),
+                uuid: "uuid1".to_string(),
+                timestamp: "2024-01-01T00:00:00Z".to_string(),
+                session_id: "session1".to_string(),
+                role: "user".to_string(),
+                text: "test message 1".to_string(),
+                message_type: "message".to_string(),
+                query: QueryCondition::Literal {
+                    pattern: "test".to_string(),
+                    case_sensitive: false,
+                },
+                cwd: "/project1".to_string(),
+                raw_json: None,
+            },
+            SearchResult {
+                file: "file1.jsonl".to_string(),
+                uuid: "uuid2".to_string(),
+                timestamp: "2024-01-01T01:00:00Z".to_string(),
+                session_id: "session1".to_string(),
+                role: "assistant".to_string(),
+                text: "test response 1".to_string(),
+                message_type: "message".to_string(),
+                query: QueryCondition::Literal {
+                    pattern: "test".to_string(),
+                    case_sensitive: false,
+                },
+                cwd: "/project1".to_string(),
+                raw_json: None,
+            },
+            SearchResult {
+                file: "file2.jsonl".to_string(),
+                uuid: "uuid3".to_string(),
+                timestamp: "2024-01-02T00:00:00Z".to_string(),
+                session_id: "session2".to_string(),
+                role: "user".to_string(),
+                text: "test message 2".to_string(),
+                message_type: "message".to_string(),
+                query: QueryCondition::Literal {
+                    pattern: "test".to_string(),
+                    case_sensitive: false,
+                },
+                cwd: "/project2".to_string(),
+                raw_json: None,
+            },
+        ];
+
+        let stats = collect_statistics(&results);
+
+        assert_eq!(stats.total_messages, 3);
+        assert_eq!(stats.session_count, 2);
+        assert_eq!(stats.file_count, 2);
+        assert_eq!(stats.project_count, 2);
+        assert_eq!(stats.role_counts.get("user"), Some(&2));
+        assert_eq!(stats.role_counts.get("assistant"), Some(&1));
+        assert_eq!(stats.message_type_counts.get("message"), Some(&3));
+
+        if let Some((earliest, latest)) = &stats.timestamp_range {
+            assert_eq!(earliest, "2024-01-01T00:00:00Z");
+            assert_eq!(latest, "2024-01-02T00:00:00Z");
+        } else {
+            panic!("Expected timestamp range to be set");
+        }
     }
 
     #[test]

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,419 @@
+use std::collections::{HashMap, HashSet};
+
+#[derive(Debug, Default)]
+pub struct Statistics {
+    pub total_messages: usize,
+    pub role_counts: HashMap<String, usize>,
+    pub session_count: usize,
+    pub unique_sessions: HashSet<String>,
+    pub file_count: usize,
+    pub unique_files: HashSet<String>,
+    pub timestamp_range: Option<(String, String)>, // (earliest, latest)
+    pub project_count: usize,
+    pub unique_projects: HashSet<String>,
+    pub message_type_counts: HashMap<String, usize>,
+}
+
+impl Statistics {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn add_message(
+        &mut self,
+        role: &str,
+        session_id: &str,
+        file: &str,
+        timestamp: &str,
+        cwd: &str,
+        message_type: &str,
+    ) {
+        self.total_messages += 1;
+
+        // Count by role
+        *self.role_counts.entry(role.to_string()).or_insert(0) += 1;
+
+        // Count by message type
+        *self
+            .message_type_counts
+            .entry(message_type.to_string())
+            .or_insert(0) += 1;
+
+        // Track unique sessions
+        if self.unique_sessions.insert(session_id.to_string()) {
+            self.session_count += 1;
+        }
+
+        // Track unique files
+        if self.unique_files.insert(file.to_string()) {
+            self.file_count += 1;
+        }
+
+        // Track unique projects
+        if self.unique_projects.insert(cwd.to_string()) {
+            self.project_count += 1;
+        }
+
+        // Update timestamp range
+        match &mut self.timestamp_range {
+            None => {
+                self.timestamp_range = Some((timestamp.to_string(), timestamp.to_string()));
+            }
+            Some((earliest, latest)) => {
+                if timestamp < earliest.as_str() {
+                    *earliest = timestamp.to_string();
+                }
+                if timestamp > latest.as_str() {
+                    *latest = timestamp.to_string();
+                }
+            }
+        }
+    }
+}
+
+pub fn format_statistics(stats: &Statistics, use_color: bool) -> String {
+    use colored::Colorize;
+
+    let mut output = String::new();
+
+    if use_color {
+        output.push_str(&"Statistics".bright_blue().bold().to_string());
+        output.push('\n');
+        output.push_str(&"═".repeat(60).bright_blue().to_string());
+        output.push_str("\n\n");
+
+        // Total messages
+        output.push_str(&format!(
+            "{}: {}\n",
+            "Total Messages".bright_yellow(),
+            stats.total_messages.to_string().bright_green()
+        ));
+
+        // Sessions
+        output.push_str(&format!(
+            "{}: {}\n",
+            "Sessions".bright_yellow(),
+            stats.session_count.to_string().bright_green()
+        ));
+
+        // Files
+        output.push_str(&format!(
+            "{}: {}\n",
+            "Files".bright_yellow(),
+            stats.file_count.to_string().bright_green()
+        ));
+
+        // Projects
+        if stats.project_count > 0 {
+            output.push_str(&format!(
+                "{}: {}\n",
+                "Projects".bright_yellow(),
+                stats.project_count.to_string().bright_green()
+            ));
+        }
+
+        // Message types
+        if !stats.message_type_counts.is_empty() {
+            output.push_str(&format!("\n{}\n", "Message Types".bright_yellow().bold()));
+            output.push_str(&"─".repeat(30).bright_blue().to_string());
+            output.push('\n');
+
+            let mut types: Vec<_> = stats.message_type_counts.iter().collect();
+            types.sort_by_key(|(_, count)| std::cmp::Reverse(**count));
+
+            for (msg_type, count) in types {
+                output.push_str(&format!(
+                    "  {}: {}\n",
+                    msg_type.bright_cyan(),
+                    count.to_string().bright_white()
+                ));
+            }
+        }
+
+        // Roles breakdown
+        if !stats.role_counts.is_empty() {
+            output.push_str(&format!(
+                "\n{}\n",
+                "Messages by Role".bright_yellow().bold()
+            ));
+            output.push_str(&"─".repeat(30).bright_blue().to_string());
+            output.push('\n');
+
+            let mut roles: Vec<_> = stats.role_counts.iter().collect();
+            roles.sort_by_key(|(_, count)| std::cmp::Reverse(**count));
+
+            for (role, count) in roles {
+                let percentage = (*count as f64 / stats.total_messages as f64 * 100.0) as u32;
+                output.push_str(&format!(
+                    "  {}: {} ({}%)\n",
+                    role.bright_cyan(),
+                    count.to_string().bright_white(),
+                    percentage.to_string().dimmed()
+                ));
+            }
+        }
+
+        // Time range
+        if let Some((earliest, latest)) = &stats.timestamp_range {
+            output.push_str(&format!("\n{}\n", "Time Range".bright_yellow().bold()));
+            output.push_str(&"─".repeat(30).bright_blue().to_string());
+            output.push('\n');
+
+            // Try to parse and format timestamps
+            let earliest_formatted = format_timestamp(earliest);
+            let latest_formatted = format_timestamp(latest);
+
+            output.push_str(&format!(
+                "  {}: {}\n",
+                "Earliest".bright_cyan(),
+                earliest_formatted.bright_white()
+            ));
+            output.push_str(&format!(
+                "  {}: {}\n",
+                "Latest".bright_cyan(),
+                latest_formatted.bright_white()
+            ));
+        }
+    } else {
+        output.push_str("Statistics\n");
+        output.push_str(&"=".repeat(60));
+        output.push_str("\n\n");
+
+        output.push_str(&format!("Total Messages: {}\n", stats.total_messages));
+        output.push_str(&format!("Sessions: {}\n", stats.session_count));
+        output.push_str(&format!("Files: {}\n", stats.file_count));
+
+        if stats.project_count > 0 {
+            output.push_str(&format!("Projects: {}\n", stats.project_count));
+        }
+
+        if !stats.message_type_counts.is_empty() {
+            output.push_str("\nMessage Types\n");
+            output.push_str(&"-".repeat(30));
+            output.push('\n');
+
+            let mut types: Vec<_> = stats.message_type_counts.iter().collect();
+            types.sort_by_key(|(_, count)| std::cmp::Reverse(**count));
+
+            for (msg_type, count) in types {
+                output.push_str(&format!("  {msg_type}: {count}\n"));
+            }
+        }
+
+        if !stats.role_counts.is_empty() {
+            output.push_str("\nMessages by Role\n");
+            output.push_str(&"-".repeat(30));
+            output.push('\n');
+
+            let mut roles: Vec<_> = stats.role_counts.iter().collect();
+            roles.sort_by_key(|(_, count)| std::cmp::Reverse(**count));
+
+            for (role, count) in roles {
+                let percentage = (*count as f64 / stats.total_messages as f64 * 100.0) as u32;
+                output.push_str(&format!("  {role}: {count} ({percentage}%)\n"));
+            }
+        }
+
+        if let Some((earliest, latest)) = &stats.timestamp_range {
+            output.push_str("\nTime Range\n");
+            output.push_str(&"-".repeat(30));
+            output.push('\n');
+
+            let earliest_formatted = format_timestamp(earliest);
+            let latest_formatted = format_timestamp(latest);
+
+            output.push_str(&format!("  Earliest: {earliest_formatted}\n"));
+            output.push_str(&format!("  Latest: {latest_formatted}\n"));
+        }
+    }
+
+    output
+}
+
+fn format_timestamp(timestamp: &str) -> String {
+    use chrono::{DateTime, Local, TimeZone};
+
+    if let Ok(dt) = DateTime::parse_from_rfc3339(timestamp) {
+        let local_dt = Local.from_utc_datetime(&dt.naive_utc());
+        local_dt.format("%Y-%m-%d %H:%M:%S").to_string()
+    } else {
+        timestamp.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_statistics_new() {
+        let stats = Statistics::new();
+        assert_eq!(stats.total_messages, 0);
+        assert_eq!(stats.session_count, 0);
+        assert_eq!(stats.file_count, 0);
+        assert_eq!(stats.project_count, 0);
+        assert!(stats.role_counts.is_empty());
+        assert!(stats.unique_sessions.is_empty());
+        assert!(stats.unique_files.is_empty());
+        assert!(stats.unique_projects.is_empty());
+        assert!(stats.message_type_counts.is_empty());
+        assert!(stats.timestamp_range.is_none());
+    }
+
+    #[test]
+    fn test_add_message() {
+        let mut stats = Statistics::new();
+
+        stats.add_message(
+            "user",
+            "session1",
+            "file1.jsonl",
+            "2024-01-01T00:00:00Z",
+            "/project1",
+            "message",
+        );
+
+        assert_eq!(stats.total_messages, 1);
+        assert_eq!(stats.session_count, 1);
+        assert_eq!(stats.file_count, 1);
+        assert_eq!(stats.project_count, 1);
+        assert_eq!(stats.role_counts.get("user"), Some(&1));
+        assert_eq!(stats.message_type_counts.get("message"), Some(&1));
+        assert_eq!(
+            stats.timestamp_range,
+            Some((
+                "2024-01-01T00:00:00Z".to_string(),
+                "2024-01-01T00:00:00Z".to_string()
+            ))
+        );
+
+        // Add another message from same session/file
+        stats.add_message(
+            "assistant",
+            "session1",
+            "file1.jsonl",
+            "2024-01-01T01:00:00Z",
+            "/project1",
+            "message",
+        );
+
+        assert_eq!(stats.total_messages, 2);
+        assert_eq!(stats.session_count, 1); // Still 1 unique session
+        assert_eq!(stats.file_count, 1); // Still 1 unique file
+        assert_eq!(stats.project_count, 1); // Still 1 unique project
+        assert_eq!(stats.role_counts.get("assistant"), Some(&1));
+        assert_eq!(stats.message_type_counts.get("message"), Some(&2));
+
+        // Timestamp range should be updated
+        if let Some((earliest, latest)) = &stats.timestamp_range {
+            assert_eq!(earliest, "2024-01-01T00:00:00Z");
+            assert_eq!(latest, "2024-01-01T01:00:00Z");
+        }
+    }
+
+    #[test]
+    fn test_timestamp_range_ordering() {
+        let mut stats = Statistics::new();
+
+        // Add messages in reverse chronological order
+        stats.add_message(
+            "user",
+            "session1",
+            "file1.jsonl",
+            "2024-01-03T00:00:00Z",
+            "/project1",
+            "message",
+        );
+        stats.add_message(
+            "user",
+            "session1",
+            "file1.jsonl",
+            "2024-01-01T00:00:00Z",
+            "/project1",
+            "message",
+        );
+        stats.add_message(
+            "user",
+            "session1",
+            "file1.jsonl",
+            "2024-01-02T00:00:00Z",
+            "/project1",
+            "message",
+        );
+
+        // Should still track earliest and latest correctly
+        if let Some((earliest, latest)) = &stats.timestamp_range {
+            assert_eq!(earliest, "2024-01-01T00:00:00Z");
+            assert_eq!(latest, "2024-01-03T00:00:00Z");
+        }
+    }
+
+    #[test]
+    fn test_format_statistics_without_color() {
+        let mut stats = Statistics::new();
+        stats.add_message(
+            "user",
+            "session1",
+            "file1.jsonl",
+            "2024-01-01T00:00:00Z",
+            "/project1",
+            "message",
+        );
+        stats.add_message(
+            "assistant",
+            "session1",
+            "file1.jsonl",
+            "2024-01-01T01:00:00Z",
+            "/project1",
+            "message",
+        );
+
+        let output = format_statistics(&stats, false);
+
+        assert!(output.contains("Statistics"));
+        assert!(output.contains("Total Messages: 2"));
+        assert!(output.contains("Sessions: 1"));
+        assert!(output.contains("Files: 1"));
+        assert!(output.contains("Projects: 1"));
+        assert!(output.contains("Messages by Role"));
+        assert!(output.contains("user: 1 (50%)"));
+        assert!(output.contains("assistant: 1 (50%)"));
+        assert!(output.contains("Time Range"));
+    }
+
+    #[test]
+    fn test_format_statistics_with_multiple_message_types() {
+        let mut stats = Statistics::new();
+        stats.add_message(
+            "user",
+            "session1",
+            "file1.jsonl",
+            "2024-01-01T00:00:00Z",
+            "/project1",
+            "message",
+        );
+        stats.add_message(
+            "system",
+            "session1",
+            "file1.jsonl",
+            "2024-01-01T00:00:00Z",
+            "/project1",
+            "system",
+        );
+        stats.add_message(
+            "user",
+            "session1",
+            "file1.jsonl",
+            "2024-01-01T00:00:00Z",
+            "/project1",
+            "summary",
+        );
+
+        let output = format_statistics(&stats, false);
+
+        assert!(output.contains("Message Types"));
+        assert!(output.contains("message: 1"));
+        assert!(output.contains("system: 1"));
+        assert!(output.contains("summary: 1"));
+    }
+}


### PR DESCRIPTION
## Summary
- Added `--stats` flag to display only statistics without message content
- Implemented comprehensive statistics collection including message counts by role, session counts, file counts, and time ranges
- Added tests and benchmarks for the new functionality

## Changes
- Added new `stats.rs` module with `Statistics` struct and formatting functions
- Added `--stats` CLI option that shows aggregated statistics
- Statistics include:
  - Total message count
  - Messages by role (user, assistant, system, summary) with percentages
  - Unique sessions, files, and projects count
  - Message type breakdown
  - Time range (earliest to latest message)
- Works with all existing filters (role, session, project, time)
- Added comprehensive unit tests for statistics functionality
- Added performance benchmarks for statistics collection

## Usage
```bash
# Show stats for all messages
ccms --stats ""

# Show stats for messages containing "test"
ccms --stats "test"

# Show stats for user messages only
ccms --stats --role user "query"

# Show stats for a specific project
ccms --stats --project /path/to/project "query"
```

## Test plan
- [x] Unit tests for statistics module
- [x] Integration test for collect_statistics function
- [x] Manual testing with various queries and filters
- [x] Benchmark tests for performance validation