### PR TITLE
Fix cursor movement in search bar

### DIFF
--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -380,6 +380,8 @@ impl InteractiveSearch {
             | KeyCode::Home
             | KeyCode::End
             | KeyCode::Enter => self.renderer.get_result_list_mut().handle_key(key),
+            // Handle Left/Right keys for cursor movement in search bar
+            KeyCode::Left | KeyCode::Right => self.renderer.get_search_bar_mut().handle_key(key),
             // Ctrl+P/N navigation - try search bar first, then result list
             KeyCode::Char('p') | KeyCode::Char('n') if key.modifiers == KeyModifiers::CONTROL => {
                 self.renderer

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -380,13 +380,19 @@ impl InteractiveSearch {
             | KeyCode::Home
             | KeyCode::End
             | KeyCode::Enter => self.renderer.get_result_list_mut().handle_key(key),
-            // Ctrl+P/N navigation
+            // Ctrl+P/N navigation - try search bar first, then result list
             KeyCode::Char('p') | KeyCode::Char('n') if key.modifiers == KeyModifiers::CONTROL => {
-                self.renderer.get_result_list_mut().handle_key(key)
+                self.renderer
+                    .get_search_bar_mut()
+                    .handle_key(key)
+                    .or_else(|| self.renderer.get_result_list_mut().handle_key(key))
             }
-            // Handle Ctrl+u/d for half-page scrolling
+            // Handle Ctrl+u/d - try search bar first, then result list for half-page scrolling
             KeyCode::Char('u') | KeyCode::Char('d') if key.modifiers == KeyModifiers::CONTROL => {
-                self.renderer.get_result_list_mut().handle_key(key)
+                self.renderer
+                    .get_search_bar_mut()
+                    .handle_key(key)
+                    .or_else(|| self.renderer.get_result_list_mut().handle_key(key))
             }
             KeyCode::Esc => {
                 // Try result list first (for closing preview), then fall back to search bar

--- a/src/interactive_ratatui/ui/components/search_bar.rs
+++ b/src/interactive_ratatui/ui/components/search_bar.rs
@@ -36,7 +36,10 @@ impl SearchBar {
     }
 
     pub fn set_query(&mut self, query: String) {
-        self.text_input.set_text(query);
+        // Only update if the query actually changed to preserve cursor position
+        if self.text_input.text() != query {
+            self.text_input.set_text(query);
+        }
     }
 
     pub fn set_searching(&mut self, is_searching: bool) {


### PR DESCRIPTION
## Summary
- Fixed cursor movement with arrow keys in the search bar
- Previously, cursor position was reset to the end on every render cycle
- Added tests to prevent regression

## Problem
When typing in the search bar and using left/right arrow keys to move the cursor, the cursor position was not preserved. This was because `SearchBar::set_query()` was called on every render cycle and unconditionally reset the cursor position to the end of the text.

## Solution
Modified `SearchBar::set_query()` to only update the text (and cursor position) when the query actually changes. This preserves the cursor position during render cycles while still allowing external query updates to work correctly.

## Changes
1. Added check in `SearchBar::set_query()` to compare current and new query values
2. Only call `TextInput::set_text()` when values differ
3. Added explicit handling for Left/Right keys in `handle_search_mode_input()`
4. Added comprehensive tests for cursor position behavior

## Test plan
- [x] Manual testing: Type "aaa" and use arrow keys to move cursor
- [x] Unit tests added:
  - `test_cursor_position_preserved_on_set_query`
  - `test_cursor_position_reset_on_different_query`
  - `test_arrow_keys_cursor_movement`
- [x] All existing tests pass