### PR TITLE
Pin Rust version to 1.88.0 for stable let-chains support

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.88.0"
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
## Summary
- Add `rust-toolchain.toml` to pin Rust version to 1.88.0
- Ensures consistent builds across all development environments and CI/CD pipelines
- Rust 1.88.0 includes stable support for let-chains feature (if-let chains) which is used throughout the codebase

## Context
The codebase uses let-chains syntax (`if let ... && let ...`) which became stable in Rust 1.88.0. Without this toolchain file, builds would fail on older Rust versions with "let expressions in this position are unstable" errors.

## Changes
- Added `rust-toolchain.toml` specifying Rust 1.88.0 with rustfmt and clippy components

## Test plan
- [x] Verified build succeeds with `cargo build --release`
- [x] All tests pass with `cargo test` (333 tests passed)
- [x] Toolchain automatically switches when entering the project directory

🤖 Generated with [Claude Code](https://claude.ai/code)