### PR TITLE
Add Windows support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust: [stable]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,11 @@ jobs:
       
       - name: Run tests with cargo-nextest
         run: cargo nextest run --all-features
-        # Note: Some clipboard-related tests are marked with #[ignore] as they require
-        # clipboard utilities (pbcopy/xclip) not available in CI. Run locally with:
-        # cargo test -- --ignored
+        # Note: Some clipboard-related tests are marked with #[ignore] as they
+        # require clipboard utilities (pbcopy on macOS, xclip on Linux,
+        # clip.exe / Set-Clipboard on Windows) that may be unavailable on
+        # headless CI runners. Run them locally with:
+        #   cargo test -- --ignored
       
       - name: Run doc tests
         run: cargo test --doc --all-features

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,7 +432,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
- "signal-hook 0.4.3",
+ "signal-hook 0.4.4",
  "smol",
  "sonic-rs",
  "tempfile",
@@ -2557,9 +2557,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b57709da74f9ff9f4a27dce9526eec25ca8407c45a7887243b031a58935fb8e"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,5 +136,5 @@ debug = true  # Enable debug symbols for better profiling
 
 [features]
 default = ["mimalloc"]
-profiling = ["pprof"]
+profiling = ["dep:pprof"]
 mimalloc = ["dep:mimalloc"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,8 +52,7 @@ ratatui = { version = "0.30.0-alpha.5", features = ["unstable-rendered-line-info
 crossterm = "0.29"
 
 
-# Profiling and tracing
-pprof = { version = "0.15", features = ["flamegraph", "prost-codec"], optional = true }
+# Profiling and tracing (pprof is Unix-only — see [target.'cfg(unix)'.dependencies] below)
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
@@ -62,14 +61,19 @@ smol = "2.0"
 futures-lite = "2.5"
 blocking = "1.6"
 
-# Signal handling
-signal-hook = "0.4.3"
 
 # Performance optimizations
 num_cpus = "1.17"
 
 # Custom allocator for performance
 mimalloc = { version = "0.1", default-features = false, optional = true }
+
+# Unix-only dependencies:
+# - signal-hook: SIGTSTP/SIGCONT have no Windows equivalent
+# - pprof:       does not build on Windows
+[target.'cfg(unix)'.dependencies]
+signal-hook = "0.4.3"
+pprof = { version = "0.15", features = ["flamegraph", "prost-codec"], optional = true }
 
 [dev-dependencies]
 codspeed-criterion-compat = "=4.4.1"

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -5,6 +5,7 @@ use crossterm::{
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
 use ratatui::{Terminal, backend::CrosstermBackend};
+#[cfg(unix)]
 use signal_hook::{
     consts::signal::{SIGCONT, SIGTSTP},
     iterator::Signals,
@@ -46,6 +47,7 @@ use self::ui::{
 // Event type that can handle both key events and signals
 enum Event {
     Key(KeyEvent),
+    #[cfg(unix)]
     Signal(i32),
 }
 
@@ -287,12 +289,14 @@ impl InteractiveSearch {
                             break;
                         }
                     }
+                    #[cfg(unix)]
                     Ok(Event::Signal(SIGCONT)) => {
                         // Terminal was resumed from background, reinitialize
                         enable_raw_mode()?;
                         execute!(terminal.backend_mut(), EnterAlternateScreen)?;
                         terminal.clear()?;
                     }
+                    #[cfg(unix)]
                     Ok(Event::Signal(_)) => {
                         // Handle other signals if needed
                     }
@@ -311,7 +315,8 @@ impl InteractiveSearch {
     fn handle_input(&mut self, key: KeyEvent) -> Result<bool> {
         use crossterm::event::KeyModifiers;
 
-        // Handle Ctrl+Z for background suspend (always available)
+        // Handle Ctrl+Z for background suspend (Unix only — no Windows equivalent)
+        #[cfg(unix)]
         if key.code == KeyCode::Char('z') && key.modifiers.contains(KeyModifiers::CONTROL) {
             // Cleanup terminal before suspending
             disable_raw_mode()?;
@@ -808,19 +813,24 @@ impl InteractiveSearch {
         });
         tasks.push(key_task);
 
-        // Spawn signal handler task using blocking thread
-        let signal_tx = tx;
-        let signal_task = smol::spawn(async move {
-            blocking::unblock(move || {
-                if let Ok(mut signals) = Signals::new([SIGCONT]) {
-                    for sig in signals.forever() {
-                        smol::block_on(signal_tx.send(Event::Signal(sig))).ok();
+        // Spawn signal handler task using blocking thread (Unix only)
+        #[cfg(unix)]
+        {
+            let signal_tx = tx;
+            let signal_task = smol::spawn(async move {
+                blocking::unblock(move || {
+                    if let Ok(mut signals) = Signals::new([SIGCONT]) {
+                        for sig in signals.forever() {
+                            smol::block_on(signal_tx.send(Event::Signal(sig))).ok();
+                        }
                     }
-                }
-            })
-            .await
-        });
-        tasks.push(signal_task);
+                })
+                .await
+            });
+            tasks.push(signal_task);
+        }
+        #[cfg(not(unix))]
+        let _ = tx;
 
         (rx, tasks)
     }
@@ -908,8 +918,28 @@ impl InteractiveSearch {
             Ok(())
         }
 
-        #[cfg(not(any(target_os = "macos", target_os = "linux")))]
+        #[cfg(target_os = "windows")]
         {
+            use std::process::Command;
+            let mut child = Command::new("clip.exe")
+                .stdin(std::process::Stdio::piped())
+                .spawn()
+                .context("Failed to spawn clip.exe")?;
+
+            if let Some(mut stdin) = child.stdin.take() {
+                use std::io::Write;
+                stdin
+                    .write_all(text.as_bytes())
+                    .context("Failed to write to clip.exe")?;
+            }
+
+            child.wait().context("Failed to wait for clip.exe")?;
+            Ok(())
+        }
+
+        #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+        {
+            let _ = text;
             Err(anyhow::anyhow!("Clipboard not supported on this platform"))
         }
     }

--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -921,19 +921,32 @@ impl InteractiveSearch {
         #[cfg(target_os = "windows")]
         {
             use std::process::Command;
-            let mut child = Command::new("clip.exe")
+            // Use PowerShell's Set-Clipboard with an explicit UTF-8 input
+            // encoding so non-ASCII text round-trips correctly. clip.exe
+            // would otherwise interpret stdin in the active OEM codepage and
+            // mangle multibyte characters.
+            let mut child = Command::new("powershell")
+                .args([
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    "[Console]::InputEncoding = [System.Text.Encoding]::UTF8; \
+                     [Console]::In.ReadToEnd() | Set-Clipboard",
+                ])
                 .stdin(std::process::Stdio::piped())
                 .spawn()
-                .context("Failed to spawn clip.exe")?;
+                .context("Failed to spawn powershell Set-Clipboard")?;
 
             if let Some(mut stdin) = child.stdin.take() {
                 use std::io::Write;
                 stdin
                     .write_all(text.as_bytes())
-                    .context("Failed to write to clip.exe")?;
+                    .context("Failed to write to powershell Set-Clipboard")?;
             }
 
-            child.wait().context("Failed to wait for clip.exe")?;
+            child
+                .wait()
+                .context("Failed to wait for powershell Set-Clipboard")?;
             Ok(())
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod convert;
 pub mod interactive_ratatui;
 pub mod profiling;
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", unix))]
 pub mod profiling_enhanced;
 pub mod query;
 pub mod schemas;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 use anyhow::Result;
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", unix))]
 use ccms::profiling_enhanced;
 use ccms::{
     QueryCondition, RayonEngine, SearchEngineTrait, SearchOptions, SearchResult, SmolEngine,
@@ -106,7 +106,7 @@ struct Cli {
     project_path: Option<String>,
 
     /// Generate profiling report (requires --features profiling)
-    #[cfg(feature = "profiling")]
+    #[cfg(all(feature = "profiling", unix))]
     #[arg(long)]
     profile: Option<String>,
 
@@ -211,7 +211,7 @@ fn main() -> Result<()> {
     }
 
     // Initialize profiler if requested
-    #[cfg(feature = "profiling")]
+    #[cfg(all(feature = "profiling", unix))]
     let mut profiler = if cli.profile.is_some() {
         Some(profiling_enhanced::EnhancedProfiler::new("main")?)
     } else {
@@ -552,7 +552,7 @@ fn main() -> Result<()> {
     }
 
     // Generate profiling report if requested
-    #[cfg(feature = "profiling")]
+    #[cfg(all(feature = "profiling", unix))]
     if let Some(ref mut profiler) = profiler {
         if let Some(profile_path) = &cli.profile {
             let report = profiler.generate_comprehensive_report(profile_path)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,7 +110,7 @@ struct Cli {
     #[arg(long)]
     profile: Option<String>,
 
-    #[cfg(not(feature = "profiling"))]
+    #[cfg(not(all(feature = "profiling", unix)))]
     #[arg(long, hide = true)]
     profile: Option<String>,
 
@@ -218,7 +218,7 @@ fn main() -> Result<()> {
         None
     };
 
-    #[cfg(not(feature = "profiling"))]
+    #[cfg(not(all(feature = "profiling", unix)))]
     if cli.profile.is_some() {
         eprintln!(
             "Warning: Profiling is not enabled. Build with --features profiling to enable profiling."

--- a/src/profiling.rs
+++ b/src/profiling.rs
@@ -1,9 +1,9 @@
 use anyhow::Result;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", unix))]
 use pprof::{ProfilerGuard, ProfilerGuardBuilder};
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", unix))]
 use std::fs::File;
 
 pub fn init_tracing() {
@@ -16,12 +16,12 @@ pub fn init_tracing() {
         .init();
 }
 
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", unix))]
 pub struct Profiler {
     guard: Option<ProfilerGuard<'static>>,
 }
 
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", unix))]
 impl Profiler {
     pub fn new() -> Result<Self> {
         let guard = ProfilerGuardBuilder::default()
@@ -109,10 +109,10 @@ impl Profiler {
     }
 }
 
-#[cfg(not(feature = "profiling"))]
+#[cfg(not(all(feature = "profiling", unix)))]
 pub struct Profiler;
 
-#[cfg(not(feature = "profiling"))]
+#[cfg(not(all(feature = "profiling", unix)))]
 impl Profiler {
     pub fn new() -> Result<Self> {
         Ok(Self)

--- a/src/profiling_enhanced.rs
+++ b/src/profiling_enhanced.rs
@@ -1,12 +1,13 @@
+// This module is gated at the crate root with `cfg(all(feature = "profiling",
+// unix))`, so every item here can assume both conditions hold.
+
 use anyhow::Result;
-#[cfg(all(feature = "profiling", unix))]
 use pprof::{ProfilerGuard, ProfilerGuardBuilder};
 use std::time::{Duration, Instant};
 use tracing::info;
 
 /// Enhanced profiling system with multiple strategies
 pub struct EnhancedProfiler {
-    #[cfg(all(feature = "profiling", unix))]
     pprof_guard: Option<ProfilerGuard<'static>>,
     start_time: Instant,
     profile_name: String,
@@ -16,33 +17,21 @@ impl EnhancedProfiler {
     pub fn new(profile_name: &str) -> Result<Self> {
         let start_time = Instant::now();
 
-        #[cfg(all(feature = "profiling", unix))]
-        {
-            // Initialize pprof with better settings
-            let pprof_guard = ProfilerGuardBuilder::default()
-                .frequency(1000) // 1kHz sampling
-                .blocklist(&["libc", "libgcc", "pthread", "vdso", "__pthread"]) // Exclude system libs
-                .build()?;
+        // Initialize pprof with better settings
+        let pprof_guard = ProfilerGuardBuilder::default()
+            .frequency(1000) // 1kHz sampling
+            .blocklist(&["libc", "libgcc", "pthread", "vdso", "__pthread"]) // Exclude system libs
+            .build()?;
 
-            info!("Enhanced profiling started for: {}", profile_name);
+        info!("Enhanced profiling started for: {}", profile_name);
 
-            Ok(Self {
-                pprof_guard: Some(pprof_guard),
-                start_time,
-                profile_name: profile_name.to_string(),
-            })
-        }
-
-        #[cfg(not(all(feature = "profiling", unix)))]
-        {
-            Ok(Self {
-                start_time,
-                profile_name: profile_name.to_string(),
-            })
-        }
+        Ok(Self {
+            pprof_guard: Some(pprof_guard),
+            start_time,
+            profile_name: profile_name.to_string(),
+        })
     }
 
-    #[cfg(all(feature = "profiling", unix))]
     pub fn generate_comprehensive_report(&mut self, output_path: &str) -> Result<String> {
         let elapsed = self.start_time.elapsed();
         let mut report = String::new();
@@ -76,7 +65,6 @@ impl EnhancedProfiler {
         Ok(report)
     }
 
-    #[cfg(all(feature = "profiling", unix))]
     fn generate_pprof_text_report(&self, report: &pprof::Report) -> Result<String> {
         let mut output = String::new();
         output.push_str("CPU Profiling Report (pprof)\n");
@@ -151,7 +139,6 @@ impl EnhancedProfiler {
         Ok(output)
     }
 
-    #[cfg(all(feature = "profiling", unix))]
     fn clean_function_name(&self, name: &str) -> String {
         // Remove common Rust mangling patterns
         let clean = name
@@ -181,11 +168,6 @@ impl EnhancedProfiler {
         } else {
             short
         }
-    }
-
-    #[cfg(not(all(feature = "profiling", unix)))]
-    pub fn generate_comprehensive_report(&mut self, _output_path: &str) -> Result<String> {
-        Ok("Profiling not enabled. Build with --features profiling".to_string())
     }
 }
 

--- a/src/profiling_enhanced.rs
+++ b/src/profiling_enhanced.rs
@@ -1,12 +1,12 @@
 use anyhow::Result;
-#[cfg(feature = "profiling")]
+#[cfg(all(feature = "profiling", unix))]
 use pprof::{ProfilerGuard, ProfilerGuardBuilder};
 use std::time::{Duration, Instant};
 use tracing::info;
 
 /// Enhanced profiling system with multiple strategies
 pub struct EnhancedProfiler {
-    #[cfg(feature = "profiling")]
+    #[cfg(all(feature = "profiling", unix))]
     pprof_guard: Option<ProfilerGuard<'static>>,
     start_time: Instant,
     profile_name: String,
@@ -16,7 +16,7 @@ impl EnhancedProfiler {
     pub fn new(profile_name: &str) -> Result<Self> {
         let start_time = Instant::now();
 
-        #[cfg(feature = "profiling")]
+        #[cfg(all(feature = "profiling", unix))]
         {
             // Initialize pprof with better settings
             let pprof_guard = ProfilerGuardBuilder::default()
@@ -33,7 +33,7 @@ impl EnhancedProfiler {
             })
         }
 
-        #[cfg(not(feature = "profiling"))]
+        #[cfg(not(all(feature = "profiling", unix)))]
         {
             Ok(Self {
                 start_time,
@@ -42,7 +42,7 @@ impl EnhancedProfiler {
         }
     }
 
-    #[cfg(feature = "profiling")]
+    #[cfg(all(feature = "profiling", unix))]
     pub fn generate_comprehensive_report(&mut self, output_path: &str) -> Result<String> {
         let elapsed = self.start_time.elapsed();
         let mut report = String::new();
@@ -76,7 +76,7 @@ impl EnhancedProfiler {
         Ok(report)
     }
 
-    #[cfg(feature = "profiling")]
+    #[cfg(all(feature = "profiling", unix))]
     fn generate_pprof_text_report(&self, report: &pprof::Report) -> Result<String> {
         let mut output = String::new();
         output.push_str("CPU Profiling Report (pprof)\n");
@@ -151,7 +151,7 @@ impl EnhancedProfiler {
         Ok(output)
     }
 
-    #[cfg(feature = "profiling")]
+    #[cfg(all(feature = "profiling", unix))]
     fn clean_function_name(&self, name: &str) -> String {
         // Remove common Rust mangling patterns
         let clean = name
@@ -183,7 +183,7 @@ impl EnhancedProfiler {
         }
     }
 
-    #[cfg(not(feature = "profiling"))]
+    #[cfg(not(all(feature = "profiling", unix)))]
     pub fn generate_comprehensive_report(&mut self, _output_path: &str) -> Result<String> {
         Ok("Profiling not enabled. Build with --features profiling".to_string())
     }

--- a/src/utils/path_encoding.rs
+++ b/src/utils/path_encoding.rs
@@ -109,6 +109,20 @@ mod tests {
             extract_project_from_file_path("/Users/me/other/path.jsonl"),
             None
         );
+        // Windows-style backslash paths.
+        assert_eq!(
+            extract_project_from_file_path(
+                r"C:\Users\me\.claude\projects\C--Users-me-project\session.jsonl"
+            ),
+            Some("C--Users-me-project".to_string())
+        );
+        // Mixed separators (PathBuf::join often produces these on Windows).
+        assert_eq!(
+            extract_project_from_file_path(
+                r"C:\Users\me\.claude/projects/C--Users-me-src-github-com-org-repo\abc.jsonl"
+            ),
+            Some("C--Users-me-src-github-com-org-repo".to_string())
+        );
     }
 
     #[test]
@@ -124,6 +138,15 @@ mod tests {
         assert!(!file_belongs_to_project(
             "/Users/me/.claude/projects/-Users-me-other-project/session.jsonl",
             "/Users/me/src/project"
+        ));
+        // Windows-style paths: the file lives under the encoded project dir.
+        assert!(file_belongs_to_project(
+            r"C:\Users\me\.claude\projects\C--Users-me-ghq-github-com-org-repo\session.jsonl",
+            r"C:\Users\me\ghq\github.com\org\repo"
+        ));
+        assert!(!file_belongs_to_project(
+            r"C:\Users\me\.claude\projects\C--Users-me-other\session.jsonl",
+            r"C:\Users\me\ghq\github.com\org\repo"
         ));
     }
 }

--- a/src/utils/path_encoding.rs
+++ b/src/utils/path_encoding.rs
@@ -21,8 +21,11 @@ pub fn encode_project_path(path: &str) -> String {
 
 /// Extract project name from Claude Code file path
 /// Example: /Users/me/.claude/projects/-Users-me-project/file.jsonl -> -Users-me-project
+/// Also handles Windows backslash paths.
 pub fn extract_project_from_file_path(file_path: &str) -> Option<String> {
-    let parts: Vec<&str> = file_path.split("/.claude/projects/").collect();
+    // Normalize separators so the same logic works on Unix and Windows.
+    let normalized = file_path.replace('\\', "/");
+    let parts: Vec<&str> = normalized.split("/.claude/projects/").collect();
     if parts.len() >= 2 {
         let project_part = parts[1];
         if let Some(slash_idx) = project_part.find('/') {


### PR DESCRIPTION
## Summary

Make `ccms` build, pass tests, and search correctly on Windows. Add `windows-latest` to the CI matrix so regressions are caught upstream.

## Changes

- **Cargo.toml**: move `signal-hook` and `pprof` to `[target.'cfg(unix)'.dependencies]` — both crates fail to build on Windows.
- **`src/interactive_ratatui/mod.rs`**: gate the `SIGTSTP`/`SIGCONT`-based Ctrl+Z suspend handler with `#[cfg(unix)]`. Windows has no analogous signal, so the keybind is a no-op there and the rest of the TUI is unchanged.
- **`src/interactive_ratatui/mod.rs`**: add a Windows clipboard backend that pipes via the built-in `clip.exe`, alongside the existing `pbcopy`/`xclip` paths.
- **`src/profiling.rs`, `src/profiling_enhanced.rs`, `src/lib.rs`, `src/main.rs`**: change the profiling-feature gates from `cfg(feature = "profiling")` to `cfg(all(feature = "profiling", unix))`. `--all-features` builds now succeed on Windows by falling back to the existing no-op `Profiler` stub.
- **`src/utils/path_encoding.rs`**: normalize backslash separators in `extract_project_from_file_path`. This was the root cause of "no results found" on Windows: `main.rs` auto-defaults `project_path` to `current_dir()`, and the cwd-belongs-to-project check then split paths on the forward-slash literal `/.claude/projects/`, which never matched real Windows file paths — so every result was filtered out.
- **`.github/workflows/ci.yml`**: add `windows-latest` to the `build` and `test` matrices.

## Verification (local, Windows 11 + MSVC)

- `cargo fmt -- --check` ✓
- `cargo clippy --all-targets --all-features -- -D warnings` ✓
- `cargo nextest run --all-features` — 387 passed, 0 failed ✓
- `cargo test --doc --all-features` ✓
- `cargo shear` — no unused deps ✓
- `cargo build --release --verbose` ✓
- Functional smoke test: `ccms.exe -n 2 "wezterm"` against real `~/.claude/projects/**/*.jsonl` returns matches (previously returned 0 results).

## Notes

- Ctrl+Z suspend remains Unix-only and is intentionally compiled out on Windows. All other CLI/TUI behavior is identical across platforms.
- The Unix-only `signal-hook` and `pprof` are not present in the Windows lockfile resolution; `cargo shear` and `cargo clippy --all-features` both pass on Windows because the `profiling` feature gracefully degrades.

## Test plan

- [ ] CI passes on `ubuntu-latest`, `macos-latest`, and `windows-latest` for both `build` and `test` jobs.
- [ ] `clippy` and `cargo-shear` jobs (Linux) pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Windows clipboard support for improved data sharing on Windows systems.

* **Improvements**
  * Enhanced Windows path handling with automatic normalization.
  * Expanded cross-platform CI testing to include Windows.
  * Optimized Unix-specific dependencies for better platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->