### PR TITLE
fix: ignore non-Press key events on Windows

### DIFF
--- a/src/interactive_ratatui/mod.rs
+++ b/src/interactive_ratatui/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use crossterm::{
-    event::{self, KeyCode, KeyEvent, poll},
+    event::{self, KeyCode, KeyEvent, KeyEventKind, poll},
     execute,
     terminal::{EnterAlternateScreen, LeaveAlternateScreen, disable_raw_mode, enable_raw_mode},
 };
@@ -805,6 +805,9 @@ impl InteractiveSearch {
                 // Check for key events every 50ms
                 if poll(Duration::from_millis(EVENT_POLL_INTERVAL_MS)).unwrap_or(false)
                     && let Ok(crossterm::event::Event::Key(key)) = event::read()
+                    // Windows reports Press, Repeat, and Release. We only act on Press
+                    // (Unix backends already collapse to Press-only by default).
+                    && key.kind == KeyEventKind::Press
                 {
                     let _ = key_tx.send(Event::Key(key)).await;
                 }


### PR DESCRIPTION
## Summary
- crossterm on Windows emits Press / Repeat / Release for every keystroke (Unix is Press-only by default), so the TUI was acting on each keypress twice.
- Visible symptoms on Windows: typed characters appeared duplicated in the search bar, and launching \`ccms\` immediately jumped into the message detail view because the Release event for the Enter key used to start the program leaked into the TUI as a fresh Enter.
- Fix: filter \`event::read()\` to \`KeyEventKind::Press\` in the event worker so Windows behavior matches Unix.

## Test plan
- [x] \`cargo build --release\`
- [x] Manual: typing in the search bar no longer duplicates characters on Windows 11.
- [x] Manual: \`ccms\` with no args now lands on the search screen instead of message detail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling to process only key press events, preventing unintended repeated and release event propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->